### PR TITLE
make sure users can choose rustls or native-tls

### DIFF
--- a/.github/workflows/rust.yaml
+++ b/.github/workflows/rust.yaml
@@ -24,10 +24,10 @@ jobs:
         run: cargo build
 
       - name: Build lib with native-tls
-        run: cargo build --features native-tls
+        run: cargo build --features native-tls && cargo tree --no-default-features --features native-tls | grep -q rustls && {exit 1} || echo "success"
 
       - name: Build lib with rustls
-        run: cargo build --features rustls
+        run: cargo build --features rustls && cargo tree --no-default-features --features rustls | grep -q native-tls && {exit 1} || echo "success"
 
       - name: Run format check
         run: cargo fmt --check

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,8 +18,7 @@ keywords = ["bgp", "bgpkit"]
 reqwest = {version = "0.11", default-features = false, features = ["blocking", "json"]}
 serde = {version="1.0", features = ["derive"]}
 serde_json = "1"
-
-oneio = "0.15.2"
+oneio = {version="0.15.2", default-features = false, features=["json", "remote", "compressions"]}
 regex = "1"
 anyhow = "1.0"
 chrono = "0.4"


### PR DESCRIPTION
`cargo build --features rustls` no-longer brings `native-tls` with it.

also added a check to make sure `native-tls` feature does not brings `rustls` and vice versa.