### PR TITLE
add caching support for AS information and update dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,18 +16,16 @@ keywords = ["bgp", "bgpkit"]
 
 [dependencies]
 as2org-rs = "1.0.0"
-peeringdb-rs = "0.1.0"
+peeringdb-rs = "0.1.1"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1"
-oneio = { version = "0.17.0", default-features = false, features = ["lib-core"] }
+oneio = { version = "0.18.1", default-features = false, features = ["lib-core", "json"] }
 regex = "1"
 anyhow = "1.0"
 chrono = { version = "0.4", features = ["serde"] }
 ipnet-trie = "0.2.0"
 ipnet = { version = "2.9", features = ["serde"] }
 tracing = "0.1"
-reqwest = "0.12"
-dotenvy = "0.15"
 
 [dev-dependencies]
 tracing-subscriber = "0.3"

--- a/src/asinfo/peeringdb.rs
+++ b/src/asinfo/peeringdb.rs
@@ -10,6 +10,7 @@ pub struct PeeringdbData {
     pub name_long: Option<String>,
     pub aka: Option<String>,
     pub irr_as_set: Option<String>,
+    pub website: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -29,6 +30,7 @@ impl Peeringdb {
                     name_long: net.name_long,
                     aka: net.aka,
                     irr_as_set: net.irr_as_set,
+                    website: net.website,
                 });
             };
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,7 +14,7 @@
 //!
 //! Add `bgpkit-commons` to your `Cargo.toml`'s `dependencies` section:
 //! ```toml
-//! bgpkit-commons = "0.7"
+//! bgpkit-commons = "0.8"
 //! ```
 //!
 //! `bgpkit-commons` is designed to load only the data you need. Here is an example of checking if an ASN is a bogon ASN:
@@ -154,21 +154,14 @@ impl BgpkitCommons {
         Ok(())
     }
 
+    pub fn load_asinfo_cached(&mut self) -> Result<()> {
+        self.asinfo = Some(AsInfoUtils::new_from_cached()?);
+        Ok(())
+    }
+
     /// Load AS-level relationship data
     pub fn load_as2rel(&mut self) -> Result<()> {
         self.as2rel = Some(As2relBgpkit::new()?);
         Ok(())
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn test_siblings() {
-        let mut commons = BgpkitCommons::new();
-        commons.load_asinfo(true, false, false, false).unwrap();
-        assert!(commons.asinfo_are_siblings(174, 1239).unwrap());
     }
 }

--- a/src/mrt_collectors/peers.rs
+++ b/src/mrt_collectors/peers.rs
@@ -49,20 +49,3 @@ pub fn get_mrt_collector_peers() -> Result<Vec<MrtCollectorPeer>> {
 
     Ok(peers.data)
 }
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn test_get_peers() {
-        let mut peers = get_mrt_collector_peers().unwrap();
-        assert!(!peers.is_empty());
-        // sort peers by the number of connected ASNs
-        peers.sort_by(|a, b| b.num_connected_asns.cmp(&a.num_connected_asns));
-        // print top 10 peers
-        for peer in peers.iter().take(10) {
-            println!("{:?}", peer);
-        }
-    }
-}

--- a/tests/asinfo_integration.rs
+++ b/tests/asinfo_integration.rs
@@ -30,3 +30,35 @@ fn test_basic_info() {
         "RIPE-NCC-AS Reseaux IP Europeens Network Coordination Centre (RIPE NCC)"
     );
 }
+
+#[test]
+fn test_loading_cached() {
+    // Create a new instance of BgpkitCommons.
+    let mut commons = bgpkit_commons::BgpkitCommons::new();
+
+    // Load AS information previously generated and cached.
+    commons.load_asinfo_cached().unwrap();
+
+    // Assert that the AS name for AS number 3333 is correct.
+    assert_eq!(
+        commons.asinfo_get(3333).unwrap().unwrap().name,
+        "RIPE-NCC-AS Reseaux IP Europeens Network Coordination Centre (RIPE NCC)"
+    );
+
+    let bgpkit_info = commons.asinfo_get(400644).unwrap().unwrap();
+
+    // Assert that the AS name for AS number 400644 is correct.
+    assert_eq!(bgpkit_info.name, "BGPKIT-LLC");
+
+    // Assert that the country for AS number 400644 is correct.
+    assert_eq!(bgpkit_info.country, "US");
+
+    // Assert that the additional datatsets are also loaded.
+    assert!(bgpkit_info.peeringdb.is_some());
+    assert!(bgpkit_info.hegemony.is_some());
+    assert!(bgpkit_info.as2org.is_some());
+    assert_eq!(
+        bgpkit_info.peeringdb.unwrap().irr_as_set.unwrap(),
+        "AS400644:AS-BGPKIT"
+    );
+}


### PR DESCRIPTION
This pull request introduces several new features, dependency updates, and test enhancements to improve the functionality and maintainability of the `bgpkit-commons` library. The most significant changes include adding support for loading cached Autonomous System (AS) information, updating dependencies, and introducing new methods and fields for AS-related data structures.

### Features and Enhancements:
* Added the `get_asinfo_map_cached` function to load AS information from a cached file and integrated it into the `AsInfoUtils` and `BgpkitCommons` structures. (`src/asinfo/mod.rs`, `src/lib.rs`) 
* Introduced the `get_preferred_name` method in the `AsInfo` struct to prioritize AS names from PeeringDB or AS2Org data when available. (`src/asinfo/mod.rs`)
* Added a new `website` field to the `PeeringdbData` struct to store the associated website for an AS. (`src/asinfo/peeringdb.rs`)
### Dependency Updates:
* Updated the `peeringdb-rs` dependency to version `0.1.1` and the `oneio` dependency to version `0.18.1` to include new features, such as JSON support. (`Cargo.toml`)
* Updated the `bgpkit-commons` library version in the documentation from `0.7` to `0.8`. (`src/lib.rs`)

### Testing Improvements:
* Added a new integration test (`test_loading_cached`) to verify the functionality of loading cached AS information and its associated datasets. (`tests/asinfo_integration.rs`)
* Removed outdated unit tests for sibling AS checks and MRT collector peers to streamline the test suite. (`src/lib.rs`, `src/mrt_collectors/peers.rs`)