### PR TITLE
Better serde support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 
 ## Unreleased changes
 
+### Dependencies
+
+* Made `serde` a required dependency (no longer optional) to ensure all public types can be serialized/deserialized
+* Added `Serialize` and `Deserialize` derives to all public structs that were missing them
+
 ## v0.9.0 - 2025-07-29
 
 ### Breaking changes

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ keywords = ["bgp", "bgpkit"]
 
 [dependencies]
 thiserror = "2.0"
+serde = { version = "1.0", features = ["derive"] }
 
 as2org-rs = { version = "1.0.0", optional = true }
 chrono = { version = "0.4", features = ["serde"], optional = true }
@@ -24,7 +25,6 @@ ipnet-trie = { version = "0.2.0", optional = true }
 oneio = { version = "0.18.2", optional = true }
 peeringdb-rs = { version = "0.1.1", optional = true }
 regex = { version = "1", optional = true }
-serde = { version = "1.0", features = ["derive"], optional = true }
 serde_json = { version = "1", optional = true }
 tracing = { version = "0.1", optional = true }
 
@@ -38,12 +38,12 @@ oneio = { version = "0.18.2" }
 default = ["all"]
 
 # Module features
-asinfo = ["as2org-rs", "peeringdb-rs", "oneio", "serde", "serde_json", "tracing", "chrono"]
-as2rel = ["oneio", "serde", "serde_json", "tracing"]
-bogons = ["oneio", "serde", "ipnet", "regex", "chrono"]
-countries = ["oneio", "serde"]
-mrt_collectors = ["oneio", "serde", "chrono"]
-rpki = ["oneio", "serde", "ipnet", "ipnet-trie", "chrono", "tracing"]
+asinfo = ["as2org-rs", "peeringdb-rs", "oneio", "serde_json", "tracing", "chrono"]
+as2rel = ["oneio", "serde_json", "tracing"]
+bogons = ["oneio", "ipnet", "regex", "chrono"]
+countries = ["oneio"]
+mrt_collectors = ["oneio", "chrono"]
+rpki = ["oneio", "ipnet", "ipnet-trie", "chrono", "tracing"]
 
 # Convenience feature to enable all modules
 all = ["asinfo", "as2rel", "bogons", "countries", "mrt_collectors", "rpki"]

--- a/src/as2rel/mod.rs
+++ b/src/as2rel/mod.rs
@@ -92,6 +92,7 @@ impl As2relEntry {
     }
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct As2relBgpkit {
     v4_rels_map: HashMap<(u32, u32), HashSet<As2relEntry>>,
     v6_rels_map: HashMap<(u32, u32), HashSet<As2relEntry>>,

--- a/src/asinfo/sibling_orgs.rs
+++ b/src/asinfo/sibling_orgs.rs
@@ -1,9 +1,11 @@
 use crate::Result;
+use serde::{Deserialize, Serialize};
 use std::collections::{HashMap, HashSet};
 use tracing::info;
 
 const BGPKIT_SIBLING_ORGS_URL: &str = "https://data.bgpkit.com/commons/sibling-orgs.txt";
 
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct SiblingOrgsUtils {
     sibling_orgs_map: HashMap<String, HashSet<String>>,
 }

--- a/src/countries/mod.rs
+++ b/src/countries/mod.rs
@@ -45,8 +45,7 @@ pub struct Country {
     pub neighbors: Vec<String>,
 }
 
-/// Countries data structure that contains a collection of countries
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Countries {
     countries: HashMap<String, Country>,
 }

--- a/src/rpki/cloudflare.rs
+++ b/src/rpki/cloudflare.rs
@@ -7,7 +7,7 @@ use std::str::FromStr;
 
 use super::{Rir, RoaEntry, RpkiTrie};
 
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct CfData {
     pub metadata: CfMetaData,
     pub roas: Vec<CfRoaEntry>,

--- a/src/rpki/mod.rs
+++ b/src/rpki/mod.rs
@@ -33,9 +33,11 @@ use ipnet_trie::IpnetTrie;
 use crate::errors::{load_methods, modules};
 use crate::{BgpkitCommons, BgpkitCommonsError, LazyLoadable, Result};
 pub use cloudflare::*;
+use serde::{Deserialize, Serialize};
 use std::fmt::Display;
 use std::str::FromStr;
 
+#[derive(Clone)]
 pub struct RpkiTrie {
     pub trie: IpnetTrie<Vec<RoaEntry>>,
     pub aspas: Vec<CfAspaEntry>,
@@ -52,7 +54,7 @@ impl Default for RpkiTrie {
     }
 }
 
-#[derive(Clone, Debug, Copy)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct RoaEntry {
     pub prefix: IpNet,
     pub asn: u32,
@@ -62,7 +64,7 @@ pub struct RoaEntry {
     pub not_after: Option<NaiveDateTime>,
 }
 
-#[derive(Clone, Debug, Copy, PartialEq, Eq)]
+#[derive(Clone, Debug, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub enum Rir {
     AFRINIC,
     APNIC,
@@ -170,7 +172,7 @@ impl RpkiTrie {
             if p.contains(prefix) {
                 for roa in roas {
                     if roa.max_length >= prefix.prefix_len() {
-                        all_matches.push(*roa);
+                        all_matches.push(roa.clone());
                     }
                 }
             }


### PR DESCRIPTION
- Made serde a required dependency instead of optional
- Added Serialize and Deserialize derives to:
  - As2relBgpkit
  - SiblingOrgsUtils
  - Countries
  - RoaEntry
  - Rir enum
- Updated feature dependencies to remove redundant serde references
- Ensures all public types can be serialized/deserialized consistently