### PR TITLE
feat(rpki): add ETag/conditional loading for Cloudflare RPKI data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,12 +15,14 @@ All notable changes to this project will be documented in this file.
     - The Cloudflare fetch path now advertises `Accept-Encoding: gzip` with transparent decompression,
       reducing transfer size from ~97 MB to ~4.6 MB; this also applies to `RpkiTrie::from_cloudflare()`
     - New internal `RpkiClientData::from_url_conditional()` with unit tests against a mock HTTP server
-      covering full load, `304 Not Modified`, and validator header passthrough
+      covering full load, `304 Not Modified`, validator header passthrough, transparent gzip
+      content-encoding, and suffix-based `.gz` decompression (already-gzipped resources still decode
+      exactly once)
 
 ### Dependencies
 
-* Added optional `reqwest` dependency (blocking, gzip, rustls) under the `rpki` feature flag for
-  header-aware HTTP requests; `oneio` remains in use for compression-by-extension sources
+* Bumped `oneio` to 0.24 and enabled its `reqwest-gzip` + `rustls` features for header-aware HTTP
+  requests; conditional loading uses `oneio::reqwest` instead of adding a direct `reqwest` dependency
 
 ## v0.10.3 - 2026-03-21
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,26 @@
 
 All notable changes to this project will be documented in this file.
 
+## Unreleased
+
+### New features
+
+* Added ETag/conditional loading for real-time RPKI data ([#33](https://github.com/bgpkit/bgpkit-commons/issues/33))
+    - New `RpkiTrie::from_cloudflare_conditional(etag, last_modified)` sends `If-None-Match`/`If-Modified-Since`
+      and returns `Ok(None)` on `304 Not Modified`, letting long-running services poll frequently without
+      re-downloading and re-parsing the full ~97 MB payload
+    - New `RpkiLoad` struct bundles the freshly built `RpkiTrie` with the source's `ETag`/`Last-Modified`
+      validators for the next poll (designed for atomic poll-and-swap, e.g. with `arc-swap`)
+    - The Cloudflare fetch path now advertises `Accept-Encoding: gzip` with transparent decompression,
+      reducing transfer size from ~97 MB to ~4.6 MB; this also applies to `RpkiTrie::from_cloudflare()`
+    - New internal `RpkiClientData::from_url_conditional()` with unit tests against a mock HTTP server
+      covering full load, `304 Not Modified`, and validator header passthrough
+
+### Dependencies
+
+* Added optional `reqwest` dependency (blocking, gzip, rustls) under the `rpki` feature flag for
+  header-aware HTTP requests; `oneio` remains in use for compression-by-extension sources
+
 ## v0.10.3 - 2026-03-21
 
 ### New features

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,11 +21,11 @@ serde = { version = "1.0", features = ["derive"] }
 chrono = { version = "0.4", features = ["serde"], optional = true }
 ipnet = { version = "2.9", features = ["serde"], optional = true }
 ipnet-trie = { version = "0.3.0", optional = true }
-oneio = { version = "0.20.0", optional = true, features = ["json", "xz"] }
-reqwest = { version = "0.12", optional = true, default-features = false, features = [
-    "blocking",
-    "gzip",
-    "rustls-tls",
+oneio = { version = "0.24.0", optional = true, features = [
+    "json",
+    "xz",
+    "reqwest-gzip",
+    "rustls",
 ] }
 regex = { version = "1", optional = true }
 serde_json = { version = "1", optional = true }
@@ -37,7 +37,7 @@ bcder = { version = "0.7", optional = true }
 [dev-dependencies]
 tracing-subscriber = "0.3"
 serde_json = "1"
-oneio = { version = "0.20.0", features = ["json", "xz"] }
+oneio = { version = "0.24.0", features = ["json", "xz", "reqwest-gzip", "rustls"] }
 
 
 [features]
@@ -49,7 +49,7 @@ as2rel = ["oneio", "serde_json", "tracing"]
 bogons = ["oneio", "ipnet", "regex", "chrono"]
 countries = ["oneio"]
 mrt_collectors = ["oneio", "chrono"]
-rpki = ["oneio", "reqwest", "ipnet", "ipnet-trie", "chrono", "tracing", "tar", "serde_json", "zstd", "bcder"]
+rpki = ["oneio", "ipnet", "ipnet-trie", "chrono", "tracing", "tar", "serde_json", "zstd", "bcder"]
 
 # Convenience feature to enable all modules
 all = ["asinfo", "as2rel", "bogons", "countries", "mrt_collectors", "rpki"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,11 @@ chrono = { version = "0.4", features = ["serde"], optional = true }
 ipnet = { version = "2.9", features = ["serde"], optional = true }
 ipnet-trie = { version = "0.3.0", optional = true }
 oneio = { version = "0.20.0", optional = true, features = ["json", "xz"] }
+reqwest = { version = "0.12", optional = true, default-features = false, features = [
+    "blocking",
+    "gzip",
+    "rustls-tls",
+] }
 regex = { version = "1", optional = true }
 serde_json = { version = "1", optional = true }
 tracing = { version = "0.1", optional = true }
@@ -44,7 +49,7 @@ as2rel = ["oneio", "serde_json", "tracing"]
 bogons = ["oneio", "ipnet", "regex", "chrono"]
 countries = ["oneio"]
 mrt_collectors = ["oneio", "chrono"]
-rpki = ["oneio", "ipnet", "ipnet-trie", "chrono", "tracing", "tar", "serde_json", "zstd", "bcder"]
+rpki = ["oneio", "reqwest", "ipnet", "ipnet-trie", "chrono", "tracing", "tar", "serde_json", "zstd", "bcder"]
 
 # Convenience feature to enable all modules
 all = ["asinfo", "as2rel", "bogons", "countries", "mrt_collectors", "rpki"]

--- a/src/asinfo/as2org.rs
+++ b/src/asinfo/as2org.rs
@@ -11,6 +11,7 @@ use chrono::NaiveDate;
 use regex::Regex;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
+use std::io::{BufRead, Read};
 
 /// Organization JSON format from CAIDA dataset
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -236,7 +237,8 @@ fn fix_latin1_misinterpretation(input: &str) -> String {
 fn parse_as2org_file(path: &str) -> Result<Vec<As2orgJsonEntry>> {
     let mut res: Vec<As2orgJsonEntry> = vec![];
 
-    for line in oneio::read_lines(path)? {
+    let reader = oneio::get_reader(path)?;
+    for line in std::io::BufReader::new(reader).lines() {
         let line = fix_latin1_misinterpretation(&line?);
         if line.contains(r#""type":"ASN""#) {
             let data = serde_json::from_str::<As2orgJsonAs>(line.as_str());
@@ -273,7 +275,8 @@ fn parse_as2org_file(path: &str) -> Result<Vec<As2orgJsonEntry>> {
 fn get_all_files_with_dates() -> Result<Vec<(String, NaiveDate)>> {
     let data_link: Regex = Regex::new(r".*(\d{8}\.as-org2info\.jsonl\.gz).*")
         .map_err(|e| BgpkitCommonsError::Internal(format!("failed to compile regex: {}", e)))?;
-    let content = oneio::read_to_string(BASE_URL)?;
+    let mut content = String::new();
+    oneio::get_reader(BASE_URL)?.read_to_string(&mut content)?;
     let mut res: Vec<(String, NaiveDate)> = data_link
         .captures_iter(content.as_str())
         .filter_map(|cap| {

--- a/src/asinfo/hegemony.rs
+++ b/src/asinfo/hegemony.rs
@@ -2,6 +2,7 @@ use crate::errors::data_sources;
 use crate::{BgpkitCommonsError, Result};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
+use std::io::BufRead;
 use tracing::{debug, info};
 
 const IIJ_IHR_HEGEMONY_IPV4_GLOBAL: &str =
@@ -25,7 +26,8 @@ fn load_hegemony(path: &str) -> Result<Vec<(u32, f64)>> {
     info!("loading hegemony scores from {}", path);
     // load global hegemony scores data CSV file with header where there are two columns: ASN, score
     let mut hegemony = Vec::new();
-    for line in oneio::read_lines(path)? {
+    let reader = oneio::get_reader(path)?;
+    for line in std::io::BufReader::new(reader).lines() {
         let text = line.ok().ok_or_else(|| {
             BgpkitCommonsError::data_source_error(data_sources::IIJ_IHR, "error reading line")
         })?;

--- a/src/asinfo/mod.rs
+++ b/src/asinfo/mod.rs
@@ -122,6 +122,7 @@ use crate::{BgpkitCommons, BgpkitCommonsError, LazyLoadable, Result};
 use serde::{Deserialize, Serialize};
 use sibling_orgs::SiblingOrgsUtils;
 use std::collections::HashMap;
+use std::io::{BufRead, Read};
 use tracing::info;
 
 pub use hegemony::HegemonyData;
@@ -327,7 +328,8 @@ impl LazyLoadable for AsInfoUtils {
 pub fn get_asinfo_map_cached() -> Result<HashMap<u32, AsInfo>> {
     info!("loading asinfo from previously generated BGPKIT cache file...");
     let mut asnames_map = HashMap::new();
-    for line in oneio::read_lines(BGPKIT_ASNINFO_URL)? {
+    let reader = oneio::get_reader(BGPKIT_ASNINFO_URL)?;
+    for line in std::io::BufReader::new(reader).lines() {
         let line = line?;
         if line.trim().is_empty() {
             continue;
@@ -345,9 +347,14 @@ pub fn get_asinfo_map(
     load_peeringdb: bool,
 ) -> Result<HashMap<u32, AsInfo>> {
     info!("loading asinfo from RIPE NCC...");
-    let text = match oneio::read_to_string(BGPKIT_ASN_TXT_MIRROR_URL) {
+    let read_text = |url: &str| -> Result<String> {
+        let mut text = String::new();
+        oneio::get_reader(url)?.read_to_string(&mut text)?;
+        Ok(text)
+    };
+    let text = match read_text(BGPKIT_ASN_TXT_MIRROR_URL) {
         Ok(t) => t,
-        Err(_) => match oneio::read_to_string(RIPE_RIS_ASN_TXT_URL) {
+        Err(_) => match read_text(RIPE_RIS_ASN_TXT_URL) {
             Ok(t) => t,
             Err(e) => {
                 return Err(BgpkitCommonsError::data_source_error(

--- a/src/asinfo/peeringdb.rs
+++ b/src/asinfo/peeringdb.rs
@@ -85,34 +85,22 @@ fn get_peeringdb_reader(url: &str) -> Result<Box<dyn Read + Send>> {
         "".to_string()
     });
 
-    let client = oneio::remote::create_client_with_headers([
-        ("Authorization".to_string(), format!("Api-Key {}", api_key)),
-        (
-            "User-Agent".to_string(),
-            format!("bgpkit-commons/{}", env!("CARGO_PKG_VERSION")),
-        ),
-    ])?;
+    let authorization = format!("Api-Key {}", api_key);
+    let user_agent = format!("bgpkit-commons/{}", env!("CARGO_PKG_VERSION"));
+    let mut client_builder = oneio::OneIo::builder().header_str("User-Agent", &user_agent);
+    // PeeringDB returns 400 Bad Request for an empty `Api-Key` header once
+    // `Accept-Encoding: gzip` is advertised; omit the header when unauthenticated.
+    if !api_key.is_empty() {
+        client_builder = client_builder.header_str("Authorization", &authorization);
+    }
+    let client = client_builder.build()?;
 
-    let res = client
-        .execute(client.get(url).build().map_err(|e| {
-            BgpkitCommonsError::data_source_error(
-                crate::errors::data_sources::PEERINGDB,
-                format!("failed to build request: {}", e),
-            )
-        })?)
-        .map_err(|e| {
-            BgpkitCommonsError::data_source_error(
-                crate::errors::data_sources::PEERINGDB,
-                format!("request failed: {}", e),
-            )
-        })?
-        .error_for_status()
-        .map_err(|e| {
-            BgpkitCommonsError::data_source_error(
-                crate::errors::data_sources::PEERINGDB,
-                format!("API returned error status: {}", e),
-            )
-        })?;
+    let res = client.get_http_reader_raw(url).map_err(|e| {
+        BgpkitCommonsError::data_source_error(
+            crate::errors::data_sources::PEERINGDB,
+            format!("request failed: {}", e),
+        )
+    })?;
 
     Ok(Box::new(res))
 }

--- a/src/asinfo/sibling_orgs.rs
+++ b/src/asinfo/sibling_orgs.rs
@@ -1,6 +1,7 @@
 use crate::Result;
 use serde::{Deserialize, Serialize};
 use std::collections::{HashMap, HashSet};
+use std::io::BufRead;
 use tracing::info;
 
 const BGPKIT_SIBLING_ORGS_URL: &str = "https://data.bgpkit.com/commons/sibling-orgs.txt";
@@ -17,7 +18,8 @@ impl SiblingOrgsUtils {
             BGPKIT_SIBLING_ORGS_URL
         );
         let mut sibling_orgs = vec![];
-        for line in oneio::read_lines(BGPKIT_SIBLING_ORGS_URL)? {
+        let reader = oneio::get_reader(BGPKIT_SIBLING_ORGS_URL)?;
+        for line in std::io::BufReader::new(reader).lines() {
             let line_str = line?.trim().to_string();
             if line_str.is_empty() || line_str.starts_with('#') {
                 // skip empty line or line started with #

--- a/src/bogons/asn.rs
+++ b/src/bogons/asn.rs
@@ -2,6 +2,7 @@ use crate::bogons::utils::{find_rfc_links, remove_footnotes, replace_commas_in_q
 use crate::errors::data_sources;
 use crate::{BgpkitCommonsError, Result};
 use serde::{Deserialize, Serialize};
+use std::io::BufRead;
 
 const IANA_ASN_SPECIAL_REGISTRY: &str = "https://www.iana.org/assignments/iana-as-numbers-special-registry/special-purpose-as-numbers.csv";
 
@@ -32,7 +33,8 @@ fn convert_to_range(s: &str) -> Result<(u32, u32)> {
 pub fn load_bogon_asns() -> Result<Vec<BogonAsn>> {
     let mut bogons = Vec::new();
     let mut prev_line: Option<String> = None;
-    for line in oneio::read_lines(IANA_ASN_SPECIAL_REGISTRY)? {
+    let reader = oneio::get_reader(IANA_ASN_SPECIAL_REGISTRY)?;
+    for line in std::io::BufReader::new(reader).lines() {
         let mut text = line.ok().ok_or_else(|| {
             BgpkitCommonsError::data_source_error(data_sources::IANA, "error reading line")
         })?;

--- a/src/bogons/prefix.rs
+++ b/src/bogons/prefix.rs
@@ -4,6 +4,7 @@ use crate::{BgpkitCommonsError, Result};
 use chrono::NaiveDate;
 use ipnet::IpNet;
 use serde::{Deserialize, Serialize};
+use std::io::BufRead;
 
 const IANA_PREFIX_SPECIAL_REGISTRY: [&str; 2] = [
     "https://www.iana.org/assignments/iana-ipv4-special-registry/iana-ipv4-special-registry-1.csv",
@@ -39,7 +40,8 @@ pub fn load_bogon_prefixes() -> Result<Vec<BogonPrefix>> {
     let mut bogons = Vec::new();
     for iana_link in IANA_PREFIX_SPECIAL_REGISTRY {
         let mut prev_line: Option<String> = None;
-        for line in oneio::read_lines(iana_link)? {
+        let reader = oneio::get_reader(iana_link)?;
+        for line in std::io::BufReader::new(reader).lines() {
             let mut text = line.ok().ok_or_else(|| {
                 BgpkitCommonsError::data_source_error(data_sources::IANA, "error reading line")
             })?;

--- a/src/countries/mod.rs
+++ b/src/countries/mod.rs
@@ -23,6 +23,7 @@ use crate::errors::{data_sources, load_methods, modules};
 use crate::{BgpkitCommons, BgpkitCommonsError, LazyLoadable, Result};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
+use std::io::BufRead;
 
 /// Country data structure
 ///
@@ -55,7 +56,8 @@ const DATA_URL: &str = "https://download.geonames.org/export/dump/countryInfo.tx
 impl Countries {
     pub fn new() -> Result<Self> {
         let mut countries: Vec<Country> = vec![];
-        for line in oneio::read_lines(DATA_URL)? {
+        let reader = oneio::get_reader(DATA_URL)?;
+        for line in std::io::BufReader::new(reader).lines() {
             let text = line.ok().ok_or_else(|| {
                 BgpkitCommonsError::data_source_error(data_sources::GEONAMES, "error reading line")
             })?;

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -70,6 +70,11 @@ pub enum BgpkitCommonsError {
     #[error("OneIO error: {0}")]
     OneIoError(#[from] oneio::OneIoError),
 
+    /// Reqwest errors (HTTP operations)
+    #[cfg(feature = "reqwest")]
+    #[error("HTTP error: {0}")]
+    ReqwestError(#[from] reqwest::Error),
+
     /// Parsing errors (int, float, etc.)
     #[error("Parsing error: {0}")]
     ParseIntError(#[from] std::num::ParseIntError),

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -70,11 +70,6 @@ pub enum BgpkitCommonsError {
     #[error("OneIO error: {0}")]
     OneIoError(#[from] oneio::OneIoError),
 
-    /// Reqwest errors (HTTP operations)
-    #[cfg(feature = "reqwest")]
-    #[error("HTTP error: {0}")]
-    ReqwestError(#[from] reqwest::Error),
-
     /// Parsing errors (int, float, etc.)
     #[error("Parsing error: {0}")]
     ParseIntError(#[from] std::num::ParseIntError),

--- a/src/rpki/cloudflare.rs
+++ b/src/rpki/cloudflare.rs
@@ -1,20 +1,101 @@
 //! Load current RPKI information from Cloudflare RPKI portal.
 
-use crate::Result;
+use crate::errors::data_sources;
+use crate::{BgpkitCommonsError, Result};
 
 use super::RpkiTrie;
 use super::rpki_client::RpkiClientData;
 
 const CLOUDFLARE_RPKI_URL: &str = "https://rpki.cloudflare.com/rpki.json";
 
+/// Result of loading RPKI data from the Cloudflare RPKI portal, including the
+/// HTTP validators needed for subsequent conditional requests.
+///
+/// See [`RpkiTrie::from_cloudflare_conditional`] for the poll-and-swap workflow
+/// this type is designed for.
+#[derive(Clone)]
+pub struct RpkiLoad {
+    /// The freshly built RPKI trie
+    pub trie: RpkiTrie,
+    /// Value of the source's `ETag` header, if present.
+    ///
+    /// Pass this back to [`RpkiTrie::from_cloudflare_conditional`] to receive
+    /// `Ok(None)` (a cheap ~0-byte `304 Not Modified` response) until the
+    /// upstream data actually changes.
+    pub etag: Option<String>,
+    /// Value of the source's `Last-Modified` header, if present.
+    ///
+    /// Usable as a fallback validator when the source does not provide an ETag.
+    pub last_modified: Option<String>,
+}
+
 impl RpkiTrie {
     /// Load current RPKI data from Cloudflare RPKI portal.
     ///
     /// This loads real-time RPKI data from Cloudflare's public RPKI JSON endpoint.
     /// The data includes ROAs, ASPAs, and BGPsec keys.
+    ///
+    /// The request advertises `Accept-Encoding: gzip`, reducing the transfer
+    /// size from ~97 MB to ~4.6 MB.
+    ///
+    /// For long-running services that poll frequently, prefer
+    /// [`RpkiTrie::from_cloudflare_conditional`], which skips the download and
+    /// parse entirely when the upstream data has not changed.
     pub fn from_cloudflare() -> Result<Self> {
-        let data = RpkiClientData::from_url(CLOUDFLARE_RPKI_URL)?;
-        Self::from_rpki_client_data(data, None)
+        match Self::from_cloudflare_conditional(None, None)? {
+            Some(load) => Ok(load.trie),
+            None => Err(BgpkitCommonsError::data_source_error(
+                data_sources::CLOUDFLARE,
+                "server returned 304 Not Modified for an unconditional request",
+            )),
+        }
+    }
+
+    /// Conditionally load current RPKI data from Cloudflare RPKI portal.
+    ///
+    /// Sends the given `etag` as `If-None-Match` and `last_modified` as
+    /// `If-Modified-Since`. When the upstream data has not changed, the server
+    /// responds with `304 Not Modified` and this returns `Ok(None)` without
+    /// downloading or re-parsing the ~97 MB payload.
+    ///
+    /// On change, returns `Ok(Some(`[`RpkiLoad`]))` containing a freshly built
+    /// trie and the new validator values to use for the next poll.
+    ///
+    /// # Example: poll-and-swap loop
+    ///
+    /// ```rust,no_run
+    /// use bgpkit_commons::rpki::RpkiTrie;
+    ///
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// let mut etag: Option<String> = None;
+    /// loop {
+    ///     match RpkiTrie::from_cloudflare_conditional(etag.as_deref(), None)? {
+    ///         Some(load) => {
+    ///             etag = load.etag.clone();
+    ///             // Atomically swap `load.trie` into shared state (e.g. with
+    ///             // `arc-swap`) so readers never block during the rebuild.
+    ///         }
+    ///         None => { /* unchanged: keep serving the existing trie */ }
+    ///     }
+    ///     std::thread::sleep(std::time::Duration::from_secs(300));
+    /// }
+    /// # }
+    /// ```
+    pub fn from_cloudflare_conditional(
+        etag: Option<&str>,
+        last_modified: Option<&str>,
+    ) -> Result<Option<RpkiLoad>> {
+        let Some(fetch) =
+            RpkiClientData::from_url_conditional(CLOUDFLARE_RPKI_URL, etag, last_modified)?
+        else {
+            return Ok(None);
+        };
+        let trie = Self::from_rpki_client_data(fetch.data, None)?;
+        Ok(Some(RpkiLoad {
+            trie,
+            etag: fetch.etag,
+            last_modified: fetch.last_modified,
+        }))
     }
 }
 
@@ -32,5 +113,32 @@ mod tests {
         println!("Loaded {} ASPAs", trie.aspas.len());
 
         assert!(total_roas > 0, "Should have loaded some ROAs");
+    }
+
+    #[test]
+    #[ignore] // Requires network access
+    fn test_from_cloudflare_conditional() {
+        // Initial unconditional load: must return data and an ETag validator.
+        let load = RpkiTrie::from_cloudflare_conditional(None, None)
+            .expect("Failed to load Cloudflare RPKI data")
+            .expect("Unconditional load should return data");
+        assert!(load.etag.is_some(), "Cloudflare should return an ETag");
+        assert!(load.last_modified.is_some());
+
+        // Polling with the same validators must short-circuit with Ok(None).
+        let unchanged = RpkiTrie::from_cloudflare_conditional(
+            load.etag.as_deref(),
+            load.last_modified.as_deref(),
+        )
+        .expect("Conditional request failed");
+        assert!(
+            unchanged.is_none(),
+            "Same validators should yield 304 Not Modified"
+        );
+
+        // A stale/unknown validator must trigger a full re-download.
+        let changed = RpkiTrie::from_cloudflare_conditional(Some("\"stale-etag\""), None)
+            .expect("Conditional request failed");
+        assert!(changed.is_some(), "Stale ETag should yield fresh data");
     }
 }

--- a/src/rpki/mod.rs
+++ b/src/rpki/mod.rs
@@ -17,6 +17,10 @@
 //! - **Format**: JSON with ROAs, ASPAs, and BGPsec keys
 //! - **Update Frequency**: Real-time
 //! - **Features**: Includes expiry timestamps for temporal validation
+//! - **Conditional loading**: [`RpkiTrie::from_cloudflare_conditional`] supports
+//!   `ETag`/`Last-Modified` validators so frequent pollers receive a cheap
+//!   `304 Not Modified` instead of re-downloading the full payload; responses
+//!   are gzip-compressed on the wire
 //!
 //! ## Historical Data (RIPE NCC)
 //! - **Source**: [RIPE NCC FTP archives](https://ftp.ripe.net/rpki/)
@@ -145,6 +149,7 @@ use ipnet_trie::IpnetTrie;
 
 use crate::errors::{load_methods, modules};
 use crate::{BgpkitCommons, BgpkitCommonsError, LazyLoadable, Result};
+pub use cloudflare::RpkiLoad;
 pub use ripe_historical::list_ripe_files;
 use rpki_client::RpkiClientData;
 pub use rpkispools::{

--- a/src/rpki/rpki_client.rs
+++ b/src/rpki/rpki_client.rs
@@ -289,30 +289,35 @@ impl RpkiClientData {
         etag: Option<&str>,
         last_modified: Option<&str>,
     ) -> crate::Result<Option<RpkiClientFetch>> {
-        let client = reqwest::blocking::Client::new();
-        let mut request = client.get(url);
+        let mut client_builder = oneio::OneIo::builder();
         if let Some(etag) = etag {
-            request = request.header(reqwest::header::IF_NONE_MATCH, etag);
+            client_builder = client_builder.header_str("If-None-Match", etag);
         }
         if let Some(last_modified) = last_modified {
-            request = request.header(reqwest::header::IF_MODIFIED_SINCE, last_modified);
+            client_builder = client_builder.header_str("If-Modified-Since", last_modified);
         }
+        let client = client_builder.build()?;
 
-        let response = request.send()?;
-        if response.status() == reqwest::StatusCode::NOT_MODIFIED {
+        let response = client.get_http_reader_raw(url)?;
+        if response.status() == oneio::reqwest::StatusCode::NOT_MODIFIED {
             return Ok(None);
         }
-        let response = response.error_for_status()?;
+        if !response.status().is_success() {
+            return Err(crate::BgpkitCommonsError::data_source_error(
+                "RPKI",
+                format!("HTTP status {} for {}", response.status(), url),
+            ));
+        }
 
-        let header_str = |name: reqwest::header::HeaderName| {
+        let header_str = |name: oneio::reqwest::header::HeaderName| {
             response
                 .headers()
                 .get(name)
                 .and_then(|v| v.to_str().ok())
                 .map(|s| s.to_string())
         };
-        let etag = header_str(reqwest::header::ETAG);
-        let last_modified = header_str(reqwest::header::LAST_MODIFIED);
+        let etag = header_str(oneio::reqwest::header::ETAG);
+        let last_modified = header_str(oneio::reqwest::header::LAST_MODIFIED);
         let data: RpkiClientData = serde_json::from_reader(response)?;
         Ok(Some(RpkiClientFetch {
             data,
@@ -335,7 +340,7 @@ mod tests {
     /// Spawn a minimal HTTP/1.1 server that answers one canned response per
     /// incoming connection, in order. Returns the server URL and a handle that
     /// yields the raw request texts it received.
-    fn mock_server(responses: Vec<String>) -> (String, std::thread::JoinHandle<Vec<String>>) {
+    fn mock_server(responses: Vec<Vec<u8>>) -> (String, std::thread::JoinHandle<Vec<String>>) {
         use std::io::{Read, Write};
         use std::net::TcpListener;
 
@@ -358,14 +363,14 @@ mod tests {
                     }
                 }
                 requests.push(String::from_utf8_lossy(&buf).to_string());
-                stream.write_all(response.as_bytes()).unwrap();
+                stream.write_all(&response).unwrap();
             }
             requests
         });
         (format!("http://{}", addr), handle)
     }
 
-    fn json_response(body: &str, etag: Option<&str>) -> String {
+    fn json_response(body: &str, etag: Option<&str>) -> Vec<u8> {
         let etag_header = match etag {
             Some(e) => format!(
                 "ETag: {}\r\nLast-Modified: Wed, 01 Jan 2025 00:00:00 GMT\r\n",
@@ -379,6 +384,26 @@ mod tests {
             body.len(),
             body
         )
+        .into_bytes()
+    }
+
+    fn status_response(status: &str) -> Vec<u8> {
+        format!("HTTP/1.1 {status}\r\nContent-Length: 0\r\nConnection: close\r\n\r\n").into_bytes()
+    }
+
+    fn gzip_response(body: &[u8], content_encoding: Option<&str>) -> Vec<u8> {
+        let content_encoding_header = match content_encoding {
+            Some(encoding) => format!("Content-Encoding: {}\r\n", encoding),
+            None => String::new(),
+        };
+        let mut response = format!(
+            "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\n{}Content-Length: {}\r\nConnection: close\r\n\r\n",
+            content_encoding_header,
+            body.len()
+        )
+        .into_bytes();
+        response.extend_from_slice(body);
+        response
     }
 
     const TEST_JSON: &str = r#"{
@@ -392,6 +417,18 @@ mod tests {
             }
         ]
     }"#;
+
+    /// Gzip-compressed bytes of `TEST_JSON`, pre-compressed so this test does
+    /// not need an extra compression dev-dependency.
+    const GZIP_TEST_JSON_BODY: [u8; 131] = [
+        31, 139, 8, 0, 0, 0, 0, 0, 2, 255, 171, 230, 82, 128, 2, 165, 162, 252, 196, 98, 37, 43,
+        133, 104, 184, 8, 8, 84, 163, 240, 192, 234, 10, 138, 82, 211, 50, 43, 128, 42, 149, 12,
+        45, 141, 244, 12, 244, 128, 88, 223, 200, 68, 73, 7, 83, 101, 110, 98, 133, 79, 106, 94,
+        122, 73, 6, 80, 177, 145, 9, 22, 5, 137, 197, 121, 64, 41, 51, 19, 19, 75, 51, 44, 178, 37,
+        137, 32, 75, 18, 11, 242, 50, 147, 177, 153, 158, 90, 81, 144, 89, 148, 10, 114, 178, 161,
+        185, 129, 137, 129, 153, 185, 145, 129, 1, 138, 170, 90, 56, 47, 22, 204, 170, 5, 0, 59,
+        57, 129, 253, 237, 0, 0, 0,
+    ];
 
     #[test]
     fn test_from_url_conditional_full_load() {
@@ -419,7 +456,9 @@ mod tests {
     fn test_from_url_conditional_not_modified() {
         let (url, server) = mock_server(vec![
             json_response(TEST_JSON, Some("\"v1\"")),
-            "HTTP/1.1 304 Not Modified\r\nConnection: close\r\n\r\n".to_string(),
+            "HTTP/1.1 304 Not Modified\r\nConnection: close\r\n\r\n"
+                .as_bytes()
+                .to_vec(),
         ]);
 
         let fetch = RpkiClientData::from_url_conditional(&url, None, None)
@@ -439,6 +478,20 @@ mod tests {
     }
 
     #[test]
+    fn test_from_url_conditional_rejects_http_errors() {
+        for status in ["404 Not Found", "500 Internal Server Error"] {
+            let (url, server) = mock_server(vec![status_response(status)]);
+            let error = RpkiClientData::from_url_conditional(&url, None, None).unwrap_err();
+            assert!(
+                error
+                    .to_string()
+                    .contains(status.split_once(' ').unwrap().0)
+            );
+            assert_eq!(server.join().unwrap().len(), 1);
+        }
+    }
+
+    #[test]
     fn test_from_url_conditional_sends_last_modified() {
         let (url, server) = mock_server(vec![json_response(TEST_JSON, Some("\"v2\""))]);
 
@@ -454,6 +507,46 @@ mod tests {
                 .to_lowercase()
                 .contains("if-modified-since: wed, 01 jan 2025 00:00:00 gmt"),
             "request should carry If-Modified-Since, got: {}",
+            requests[0]
+        );
+    }
+
+    #[test]
+    fn test_from_url_conditional_transparent_gzip_decode() {
+        let (url, server) = mock_server(vec![gzip_response(&GZIP_TEST_JSON_BODY, Some("gzip"))]);
+
+        let fetch = RpkiClientData::from_url_conditional(&url, None, None)
+            .unwrap()
+            .expect("gzip-encoded unconditional request should return data");
+        assert_eq!(fetch.data.roas.len(), 1);
+        assert_eq!(fetch.data.roas[0].asn, 64496);
+
+        let requests = server.join().unwrap();
+        assert_eq!(requests.len(), 1);
+        assert!(
+            requests[0].to_lowercase().contains("accept-encoding: gzip"),
+            "request should advertise Accept-Encoding: gzip, got: {}",
+            requests[0]
+        );
+    }
+
+    #[test]
+    fn test_from_url_gzipped_suffix_still_decodes_once() {
+        // Already-gzipped resources are normally served without a
+        // `Content-Encoding: gzip` header; oneio's suffix-based `.gz`
+        // decompression must still decode them exactly once.
+        let (base_url, server) = mock_server(vec![gzip_response(&GZIP_TEST_JSON_BODY, None)]);
+        let url = format!("{}/rpki.json.gz", base_url);
+
+        let data = RpkiClientData::from_url(&url).unwrap();
+        assert_eq!(data.roas.len(), 1);
+        assert_eq!(data.roas[0].asn, 64496);
+
+        let requests = server.join().unwrap();
+        assert_eq!(requests.len(), 1);
+        assert!(
+            requests[0].to_lowercase().contains("accept-encoding: gzip"),
+            "request should advertise Accept-Encoding: gzip, got: {}",
             requests[0]
         );
     }

--- a/src/rpki/rpki_client.rs
+++ b/src/rpki/rpki_client.rs
@@ -247,6 +247,17 @@ pub(crate) struct RpkiClientBgpsecKeyEntry {
     pub expires: i64,
 }
 
+/// Result of a successful (non-304) conditional fetch of rpki-client JSON data.
+#[derive(Debug)]
+pub(crate) struct RpkiClientFetch {
+    /// The parsed rpki-client data
+    pub data: RpkiClientData,
+    /// Value of the response `ETag` header, if present
+    pub etag: Option<String>,
+    /// Value of the response `Last-Modified` header, if present
+    pub last_modified: Option<String>,
+}
+
 impl RpkiClientData {
     /// Load rpki-client data from a URL.
     ///
@@ -256,6 +267,58 @@ impl RpkiClientData {
         let reader = oneio::get_reader(url)?;
         let data: RpkiClientData = serde_json::from_reader(reader)?;
         Ok(data)
+    }
+
+    /// Conditionally load rpki-client data from a URL using HTTP validators.
+    ///
+    /// Sends `If-None-Match` (when `etag` is given) and `If-Modified-Since`
+    /// (when `last_modified` is given) request headers. Returns `Ok(None)` when
+    /// the server responds with `304 Not Modified`, meaning the caller's cached
+    /// data is still current and no re-download/re-parse is needed.
+    ///
+    /// The request advertises `Accept-Encoding: gzip` and the response body is
+    /// transparently decompressed, which significantly reduces transfer size
+    /// for large JSON payloads (e.g. ~97 MB to ~4.6 MB for Cloudflare's
+    /// `rpki.json`).
+    ///
+    /// On a `200 OK` response, returns the parsed data along with the response's
+    /// `ETag` and `Last-Modified` validator values for use in subsequent
+    /// conditional requests.
+    pub fn from_url_conditional(
+        url: &str,
+        etag: Option<&str>,
+        last_modified: Option<&str>,
+    ) -> crate::Result<Option<RpkiClientFetch>> {
+        let client = reqwest::blocking::Client::new();
+        let mut request = client.get(url);
+        if let Some(etag) = etag {
+            request = request.header(reqwest::header::IF_NONE_MATCH, etag);
+        }
+        if let Some(last_modified) = last_modified {
+            request = request.header(reqwest::header::IF_MODIFIED_SINCE, last_modified);
+        }
+
+        let response = request.send()?;
+        if response.status() == reqwest::StatusCode::NOT_MODIFIED {
+            return Ok(None);
+        }
+        let response = response.error_for_status()?;
+
+        let header_str = |name: reqwest::header::HeaderName| {
+            response
+                .headers()
+                .get(name)
+                .and_then(|v| v.to_str().ok())
+                .map(|s| s.to_string())
+        };
+        let etag = header_str(reqwest::header::ETAG);
+        let last_modified = header_str(reqwest::header::LAST_MODIFIED);
+        let data: RpkiClientData = serde_json::from_reader(response)?;
+        Ok(Some(RpkiClientFetch {
+            data,
+            etag,
+            last_modified,
+        }))
     }
 
     /// Load rpki-client data from a JSON string.
@@ -268,6 +331,132 @@ impl RpkiClientData {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// Spawn a minimal HTTP/1.1 server that answers one canned response per
+    /// incoming connection, in order. Returns the server URL and a handle that
+    /// yields the raw request texts it received.
+    fn mock_server(responses: Vec<String>) -> (String, std::thread::JoinHandle<Vec<String>>) {
+        use std::io::{Read, Write};
+        use std::net::TcpListener;
+
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let addr = listener.local_addr().unwrap();
+        let handle = std::thread::spawn(move || {
+            let mut requests = Vec::new();
+            for response in responses {
+                let (mut stream, _) = listener.accept().unwrap();
+                let mut buf = Vec::new();
+                let mut tmp = [0u8; 4096];
+                loop {
+                    let n = stream.read(&mut tmp).unwrap();
+                    if n == 0 {
+                        break;
+                    }
+                    buf.extend_from_slice(&tmp[..n]);
+                    if buf.windows(4).any(|w| w == b"\r\n\r\n") {
+                        break;
+                    }
+                }
+                requests.push(String::from_utf8_lossy(&buf).to_string());
+                stream.write_all(response.as_bytes()).unwrap();
+            }
+            requests
+        });
+        (format!("http://{}", addr), handle)
+    }
+
+    fn json_response(body: &str, etag: Option<&str>) -> String {
+        let etag_header = match etag {
+            Some(e) => format!(
+                "ETag: {}\r\nLast-Modified: Wed, 01 Jan 2025 00:00:00 GMT\r\n",
+                e
+            ),
+            None => String::new(),
+        };
+        format!(
+            "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\n{}Content-Length: {}\r\nConnection: close\r\n\r\n{}",
+            etag_header,
+            body.len(),
+            body
+        )
+    }
+
+    const TEST_JSON: &str = r#"{
+        "roas": [
+            {
+                "prefix": "192.0.2.0/24",
+                "maxLength": 24,
+                "asn": 64496,
+                "ta": "apnic",
+                "expires": 1704067200
+            }
+        ]
+    }"#;
+
+    #[test]
+    fn test_from_url_conditional_full_load() {
+        let (url, server) = mock_server(vec![json_response(TEST_JSON, Some("\"v1\""))]);
+
+        let fetch = RpkiClientData::from_url_conditional(&url, None, None)
+            .unwrap()
+            .expect("unconditional request should return data");
+
+        assert_eq!(fetch.data.roas.len(), 1);
+        assert_eq!(fetch.data.roas[0].asn, 64496);
+        assert_eq!(fetch.etag.as_deref(), Some("\"v1\""));
+        assert_eq!(
+            fetch.last_modified.as_deref(),
+            Some("Wed, 01 Jan 2025 00:00:00 GMT")
+        );
+
+        let requests = server.join().unwrap();
+        assert_eq!(requests.len(), 1);
+        assert!(!requests[0].to_lowercase().contains("if-none-match:"));
+        assert!(!requests[0].to_lowercase().contains("if-modified-since:"));
+    }
+
+    #[test]
+    fn test_from_url_conditional_not_modified() {
+        let (url, server) = mock_server(vec![
+            json_response(TEST_JSON, Some("\"v1\"")),
+            "HTTP/1.1 304 Not Modified\r\nConnection: close\r\n\r\n".to_string(),
+        ]);
+
+        let fetch = RpkiClientData::from_url_conditional(&url, None, None)
+            .unwrap()
+            .unwrap();
+        let result =
+            RpkiClientData::from_url_conditional(&url, fetch.etag.as_deref(), None).unwrap();
+        assert!(result.is_none(), "304 should map to Ok(None)");
+
+        let requests = server.join().unwrap();
+        assert_eq!(requests.len(), 2);
+        assert!(
+            requests[1].to_lowercase().contains("if-none-match: \"v1\""),
+            "second request should carry If-None-Match, got: {}",
+            requests[1]
+        );
+    }
+
+    #[test]
+    fn test_from_url_conditional_sends_last_modified() {
+        let (url, server) = mock_server(vec![json_response(TEST_JSON, Some("\"v2\""))]);
+
+        let fetch =
+            RpkiClientData::from_url_conditional(&url, None, Some("Wed, 01 Jan 2025 00:00:00 GMT"))
+                .unwrap()
+                .unwrap();
+        assert_eq!(fetch.etag.as_deref(), Some("\"v2\""));
+
+        let requests = server.join().unwrap();
+        assert!(
+            requests[0]
+                .to_lowercase()
+                .contains("if-modified-since: wed, 01 jan 2025 00:00:00 gmt"),
+            "request should carry If-Modified-Since, got: {}",
+            requests[0]
+        );
+    }
 
     #[test]
     fn test_deserialize_empty() {

--- a/src/rpki/rpkispools.rs
+++ b/src/rpki/rpkispools.rs
@@ -442,12 +442,14 @@ fn parse_aspa_payload_state<S: bcder::decode::Source>(
 pub fn parse_rpkispools_archive(url: &str) -> Result<RpkiSpoolsData> {
     info!("streaming RPKISPOOL archive: {}", url);
 
-    let reader = oneio::get_reader_raw(url).map_err(|e| {
-        crate::BgpkitCommonsError::data_source_error(
-            "RPKISPOOL",
-            format!("Failed to fetch {}: {}", url, e),
-        )
-    })?;
+    let reader = oneio::OneIo::new()
+        .and_then(|client| client.get_reader_raw(url))
+        .map_err(|e| {
+            crate::BgpkitCommonsError::data_source_error(
+                "RPKISPOOL",
+                format!("Failed to fetch {}: {}", url, e),
+            )
+        })?;
 
     // Decompress zstd stream
     let decoder = zstd::Decoder::new(reader).map_err(|e| {

--- a/src/rpki/rpkiviews.rs
+++ b/src/rpki/rpkiviews.rs
@@ -15,7 +15,7 @@ use crate::rpki::rpki_client::RpkiClientData;
 use crate::rpki::{RpkiFile, RpkiTrie};
 use chrono::{DateTime, Datelike, NaiveDate};
 use serde::{Deserialize, Serialize};
-use std::io::{Read, Write};
+use std::io::{BufRead, Read, Write};
 use std::process::{Command, Stdio};
 use std::str::FromStr;
 use tracing::info;
@@ -103,7 +103,8 @@ pub fn list_rpkiviews_files(
 
     let mut files = vec![];
 
-    for line in oneio::read_lines(&index_url)? {
+    let reader = oneio::get_reader(&index_url)?;
+    for line in std::io::BufReader::new(reader).lines() {
         let line = line?;
         let parts: Vec<&str> = line.split_whitespace().collect();
         if parts.len() < 3 {
@@ -198,12 +199,14 @@ pub fn list_files_in_tgz(url: &str, max_entries: Option<usize>) -> Result<Vec<Tg
     // Stream the .tgz file using oneio in a separate thread
     let url_owned = url.to_string();
     let writer_thread = std::thread::spawn(move || -> Result<()> {
-        let mut reader = oneio::get_reader_raw(&url_owned).map_err(|e| {
-            crate::BgpkitCommonsError::data_source_error(
-                "RPKIviews",
-                format!("Failed to fetch {}: {}", url_owned, e),
-            )
-        })?;
+        let mut reader = oneio::OneIo::new()
+            .and_then(|client| client.get_reader_raw(&url_owned))
+            .map_err(|e| {
+                crate::BgpkitCommonsError::data_source_error(
+                    "RPKIviews",
+                    format!("Failed to fetch {}: {}", url_owned, e),
+                )
+            })?;
 
         let mut buffer = [0u8; 65536];
         loop {
@@ -320,12 +323,14 @@ pub fn tgz_contains_file(url: &str, target_path: &str) -> Result<bool> {
 
     let url_owned = url.to_string();
     let writer_thread = std::thread::spawn(move || -> Result<()> {
-        let mut reader = oneio::get_reader_raw(&url_owned).map_err(|e| {
-            crate::BgpkitCommonsError::data_source_error(
-                "RPKIviews",
-                format!("Failed to fetch {}: {}", url_owned, e),
-            )
-        })?;
+        let mut reader = oneio::OneIo::new()
+            .and_then(|client| client.get_reader_raw(&url_owned))
+            .map_err(|e| {
+                crate::BgpkitCommonsError::data_source_error(
+                    "RPKIviews",
+                    format!("Failed to fetch {}: {}", url_owned, e),
+                )
+            })?;
 
         let mut buffer = [0u8; 65536];
         loop {
@@ -423,12 +428,14 @@ pub fn extract_file_from_tgz(url: &str, target_path: &str) -> Result<String> {
 
     let url_owned = url.to_string();
     let writer_thread = std::thread::spawn(move || -> Result<()> {
-        let mut reader = oneio::get_reader_raw(&url_owned).map_err(|e| {
-            crate::BgpkitCommonsError::data_source_error(
-                "RPKIviews",
-                format!("Failed to fetch {}: {}", url_owned, e),
-            )
-        })?;
+        let mut reader = oneio::OneIo::new()
+            .and_then(|client| client.get_reader_raw(&url_owned))
+            .map_err(|e| {
+                crate::BgpkitCommonsError::data_source_error(
+                    "RPKIviews",
+                    format!("Failed to fetch {}: {}", url_owned, e),
+                )
+            })?;
 
         let mut buffer = [0u8; 65536];
         loop {


### PR DESCRIPTION
## Summary

Implements #33: conditional (validator-aware) RPKI loading so long-running services can poll `rpki.json` frequently without re-downloading and re-parsing the full ~97 MB payload.

- **`RpkiTrie::from_cloudflare_conditional(etag, last_modified) -> Result<Option<RpkiLoad>>`** — sends `If-None-Match`/`If-Modified-Since`; returns `Ok(None)` on `304 Not Modified`, and `Ok(Some(RpkiLoad))` with a freshly built trie on change.
- **`RpkiLoad { trie, etag, last_modified }`** — carries source validators for the next poll and supports the atomic poll-and-swap pattern described in the issue.
- **oneio v0.24 HTTP/gzip integration** — uses oneio's `reqwest` re-export and `reqwest-gzip` feature instead of a direct reqwest dependency. The Cloudflare loader advertises `Accept-Encoding: gzip` and transparently decompresses the response (~97 MB to ~4.6 MB on the wire).
- Existing suffix-compressed resources continue to work: `.gz`, `.xz`, `.bz2`, and `.tgz` paths retain their existing oneio/streaming decompression behavior.

## Implementation notes

- Bumped oneio to `0.24.0` with `reqwest-gzip` and `rustls`; removed the optional direct `reqwest` dependency and `ReqwestError` variant.
- Conditional loading uses `oneio::OneIo::builder()` plus the public `oneio::reqwest` types for validators and status handling.
- Preserved non-2xx rejection behavior, including explicit regression coverage for 404 and 500 responses.
- Updated affected oneio reader calls for the v0.24 API while retaining streaming behavior for large archives.
- PeeringDB omits an empty `Authorization: Api-Key` header when no key is configured, avoiding a 400 response with the gzip-enabled client.

## Tests

- 6 offline HTTP tests cover full 200 loading, validator passthrough, 304 handling, HTTP gzip content-encoding, already-gzipped `.gz` resources, and non-2xx responses.
- `cargo fmt --check`
- `cargo clippy --all-features -- -D warnings`
- `cargo test --features rpki rpki_client --lib -- --nocapture` — 12 passed
- `cargo test --all-features --lib` — 43 passed, 26 ignored
- `cargo test --no-default-features` — passed, including doctests
- `cargo tree --features rpki` confirms reqwest is present only through oneio.

The full all-features doctest that live-fetches PeeringDB can be rate-limited with HTTP 429 when no API key is configured; the no-default-features doctest suite passes, and this is unrelated to the RPKI changes.

Closes #33
