### PR TITLE
feat(asinfo): fill ASNs missing from RIPE asn.txt via RIR delegated stats

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,13 @@ All notable changes to this project will be documented in this file.
   peeringdb) are looked up from the already-loaded datasets, so
   `get_preferred_name()` resolves real names for filled ASNs registered in
   PeeringDB/as2org. Fetch failures for individual files are logged and
-  skipped (best-effort). No API or schema changes.
+  files are logged and skipped (best-effort). No API or schema changes.
+* `asinfo`: optional enrichment datasets (as2org, population, hegemony,
+  peeringdb) in `get_asinfo_map()` now fail soft: a download or API error
+  (e.g., PeeringDB rate limiting without `PEERINGDB_API_KEY`) logs a warning
+  and proceeds with that dataset's fields as `None` instead of failing the
+  entire load. Core `asn.txt` + delegated-stats data still propagates load
+  errors.
 
 ## v0.12.0 - 2026-07-28
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,10 +10,14 @@ All notable changes to this project will be documented in this file.
   using the five RIR delegated stats files (ARIN, RIPE NCC, APNIC, LACNIC,
   AFRINIC). `asn.txt` lags behind new allocations by days to weeks; the
   delegated stats are authoritative, daily-updated allocation records and
-  cover newly-allocated ASNs. Filled entries carry the allocated country
-  code, an `"UNKNOWN"` name (delegated stats do not include names), and
-  `None` for all optional enrichment fields. Fetch failures for individual
-  files are logged and skipped (best-effort). No API or schema changes.
+  cover newly-allocated ASNs. Only `allocated`/`assigned` records are used
+  (reserved/available ranges excluded). Filled entries carry the allocated
+  country code and an `"UNKNOWN"` name (delegated stats do not include
+  names); optional enrichment fields (as2org, population, hegemony,
+  peeringdb) are looked up from the already-loaded datasets, so
+  `get_preferred_name()` resolves real names for filled ASNs registered in
+  PeeringDB/as2org. Fetch failures for individual files are logged and
+  skipped (best-effort). No API or schema changes.
 
 ## v0.12.0 - 2026-07-28
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to this project will be documented in this file.
 
 ## Unreleased
 
+### Changes
+
+* `asinfo`: `get_asinfo_map()` now fills ASNs missing from RIPE NCC `asn.txt`
+  using the five RIR delegated stats files (ARIN, RIPE NCC, APNIC, LACNIC,
+  AFRINIC). `asn.txt` lags behind new allocations by days to weeks; the
+  delegated stats are authoritative, daily-updated allocation records and
+  cover newly-allocated ASNs. Filled entries carry the allocated country
+  code, an `"UNKNOWN"` name (delegated stats do not include names), and
+  `None` for all optional enrichment fields. Fetch failures for individual
+  files are logged and skipped (best-effort). No API or schema changes.
+
 ## v0.12.0 - 2026-07-28
 
 ### New features

--- a/src/asinfo/mod.rs
+++ b/src/asinfo/mod.rs
@@ -3,6 +3,8 @@
 //! # Data source
 //!
 //! - RIPE NCC asinfo: <https://ftp.ripe.net/ripe/asnames/asn.txt>
+//! - RIR delegated stats (fallback fill for ASNs missing from `asn.txt`):
+//!   <https://www.nro.net/about/rirs/statistics/>
 //! - (Optional) CAIDA as-to-organization mapping: <https://www.caida.org/catalog/datasets/as-organizations/>
 //! - (Optional) APNIC AS population data: <https://stats.labs.apnic.net/cgi-bin/aspop>
 //! - (Optional) IIJ IHR Hegemony data: <https://ihr-archive.iijlab.net/>
@@ -118,7 +120,7 @@ use serde::{Deserialize, Serialize};
 use sibling_orgs::SiblingOrgsUtils;
 use std::collections::HashMap;
 use std::io::{BufRead, Read};
-use tracing::info;
+use tracing::{info, warn};
 
 pub use hegemony::HegemonyData;
 pub use population::AsnPopulationData;
@@ -171,6 +173,18 @@ pub struct As2orgInfo {
 const RIPE_RIS_ASN_TXT_URL: &str = "https://ftp.ripe.net/ripe/asnames/asn.txt";
 const BGPKIT_ASN_TXT_MIRROR_URL: &str = "https://data.bgpkit.com/commons/asn.txt";
 const BGPKIT_ASNINFO_URL: &str = "https://data.bgpkit.com/commons/asinfo.jsonl";
+
+/// RIR delegated stats files (NRO format), used to fill ASNs missing from
+/// RIPE NCC `asn.txt`. These files are authoritative allocation records,
+/// updated daily, and include newly-allocated ASNs that `asn.txt` lags on
+/// by days to weeks.
+const RIR_DELEGATED_STATS_URLS: &[&str] = &[
+    "https://ftp.arin.net/pub/stats/arin/delegated-arin-extended-latest",
+    "https://ftp.ripe.net/pub/stats/ripencc/delegated-ripencc-latest",
+    "https://ftp.apnic.net/pub/stats/apnic/delegated-apnic-latest",
+    "https://ftp.lacnic.net/pub/stats/lacnic/delegated-lacnic-latest",
+    "https://ftp.afrinic.net/pub/stats/afrinic/delegated-afrinic-latest",
+];
 
 /// Builder for configuring which data sources to load for AS information.
 ///
@@ -337,6 +351,87 @@ pub fn get_asinfo_map_cached() -> Result<HashMap<u32, AsInfo>> {
     Ok(asnames_map)
 }
 
+/// Parse RIR delegated stats text (NRO format) into an ASN -> country code map.
+///
+/// Record format: `registry|CC|type|start|value|date|status[|extensions]`.
+/// Only `asn` records with a real (non-empty, non-`*`) country code are kept;
+/// private-use ASN ranges (RFC 6996: 64512-65534 and 4200000000+) are excluded.
+/// Ranges are expanded per-ASN (`value` is a count).
+fn parse_delegated_stats(text: &str, map: &mut HashMap<u32, String>) {
+    for line in text.lines() {
+        let line = line.trim();
+        if line.is_empty() || line.starts_with('#') {
+            continue;
+        }
+        let parts: Vec<&str> = line.split('|').collect();
+        if parts.len() < 7 || parts[2] != "asn" {
+            continue;
+        }
+        let cc = parts[1].trim();
+        if cc.is_empty() || cc == "*" {
+            continue;
+        }
+        let (Ok(start), Ok(count)) = (parts[3].parse::<u64>(), parts[4].parse::<u64>()) else {
+            continue;
+        };
+        for asn in start..start.saturating_add(count) {
+            if asn > u32::MAX as u64 {
+                break;
+            }
+            let asn = asn as u32;
+            if (64512..=65534).contains(&asn) || asn >= 4_200_000_000 {
+                continue;
+            }
+            map.insert(asn, cc.to_uppercase());
+        }
+    }
+}
+
+/// Fill ASNs missing from the RIPE NCC `asn.txt`-derived map using the five
+/// RIR delegated stats files (authoritative allocation data, updated daily).
+///
+/// `asn.txt` lags behind new allocations by days to weeks; the delegated
+/// stats cover them. Synthesized entries carry the allocated country code and
+/// an `"UNKNOWN"` name (delegated stats do not include names), with all
+/// optional enrichment fields left as `None`.
+///
+/// Best-effort: failures fetching individual files are logged and skipped.
+fn fill_missing_asns_from_delegated_stats(asnames_map: &mut HashMap<u32, AsInfo>) {
+    let read_text = |url: &str| -> Result<String> {
+        let mut text = String::new();
+        oneio::get_reader(url)?.read_to_string(&mut text)?;
+        Ok(text)
+    };
+
+    let mut delegated: HashMap<u32, String> = HashMap::new();
+    for url in RIR_DELEGATED_STATS_URLS {
+        match read_text(url) {
+            Ok(text) => parse_delegated_stats(&text, &mut delegated),
+            Err(e) => warn!("failed to load delegated stats from {}: {}", url, e),
+        }
+    }
+
+    let mut filled = 0usize;
+    for (asn, country) in delegated {
+        asnames_map.entry(asn).or_insert_with(|| {
+            filled += 1;
+            AsInfo {
+                asn,
+                name: "UNKNOWN".to_string(),
+                country,
+                as2org: None,
+                population: None,
+                hegemony: None,
+                peeringdb: None,
+            }
+        });
+    }
+    info!(
+        "filled {} ASNs missing from RIPE NCC asn.txt via RIR delegated stats",
+        filled
+    );
+}
+
 pub fn get_asinfo_map(
     load_as2org: bool,
     load_population: bool,
@@ -433,6 +528,10 @@ pub fn get_asinfo_map(
     for asname in asnames {
         asnames_map.insert(asname.asn, asname);
     }
+
+    info!("filling ASNs missing from RIPE NCC asn.txt via RIR delegated stats...");
+    fill_missing_asns_from_delegated_stats(&mut asnames_map);
+
     Ok(asnames_map)
 }
 
@@ -554,5 +653,102 @@ impl BgpkitCommons {
             }
         }
         Ok(false)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_delegated_stats_basic() {
+        let text = "\
+2|ripencc|ZZ|209|20250704|00000000+000000+00000000|UTF-8
+ripencc|*|asn|*|39634|summary
+ripencc|GB|asn|219157|1|20260722|allocated
+ripencc|DE|asn|219125|1|20260728|allocated
+arin||asn|212|1||reserved|
+arin|*|asn|*|32843|summary
+arin|US|asn|402598|1|20260604|assigned|
+apnic|BD|asn|154708|1|20260609|allocated
+ripencc|NL|asn|1000|4|19970901|allocated
+ripencc|NL|ipv4|185.0.0.0|65536|20000101|allocated
+";
+        let mut map = HashMap::new();
+        parse_delegated_stats(text, &mut map);
+        assert_eq!(map.get(&219157).map(String::as_str), Some("GB"));
+        assert_eq!(map.get(&219125).map(String::as_str), Some("DE"));
+        assert_eq!(map.get(&402598).map(String::as_str), Some("US"));
+        assert_eq!(map.get(&154708).map(String::as_str), Some("BD"));
+        // range expansion: AS1000..=AS1003 (value is a count of 4)
+        assert_eq!(map.get(&1000).map(String::as_str), Some("NL"));
+        assert_eq!(map.get(&1003).map(String::as_str), Some("NL"));
+        assert!(!map.contains_key(&1004));
+        // reserved entries with empty CC are skipped
+        assert!(!map.contains_key(&212));
+        // non-asn records are skipped
+        assert_eq!(map.len(), 8);
+    }
+
+    #[test]
+    fn test_parse_delegated_stats_skips_private_and_invalid() {
+        let text = "\
+arin|US|asn|64512|1023|19891201|reserved
+arin|US|asn|4200000000|9999|19891201|reserved
+arin|US|asn|notanumber|1|20200101|allocated
+arin|US|asn|123|notacount|20200101|allocated
+";
+        let mut map = HashMap::new();
+        parse_delegated_stats(text, &mut map);
+        assert!(map.is_empty());
+    }
+
+    #[test]
+    fn test_parse_delegated_stats_private_boundary() {
+        // AS65535 (last private 16-bit ASN, not in 64512..=65534) is kept;
+        // AS65534 is dropped. RFC 6996 documentation ASN 64496 is public but
+        // unused; it is kept since only the exact private ranges are filtered.
+        let text = "\
+arin|US|asn|65535|1|19891201|allocated
+arin|US|asn|65534|1|19891201|allocated
+arin|US|asn|64496|1|19891201|allocated
+arin|US|asn|4199999999|1|19891201|allocated
+arin|US|asn|4200000000|1|19891201|allocated
+";
+        let mut map = HashMap::new();
+        parse_delegated_stats(text, &mut map);
+        assert_eq!(map.get(&65535).map(String::as_str), Some("US"));
+        assert!(!map.contains_key(&65534));
+        assert_eq!(map.get(&64496).map(String::as_str), Some("US"));
+        assert_eq!(map.get(&4199999999).map(String::as_str), Some("US"));
+        assert!(!map.contains_key(&4200000000));
+    }
+
+    #[test]
+    fn test_parse_delegated_stats_case_normalization() {
+        let text = "lacnic|br|asn|269000|1|20150101|allocated\n";
+        let mut map = HashMap::new();
+        parse_delegated_stats(text, &mut map);
+        assert_eq!(map.get(&269000).map(String::as_str), Some("BR"));
+    }
+
+    #[test]
+    fn test_parse_delegated_stats_malformed_lines() {
+        let text = "\
+# comment line
+
+ripencc|GB|asn
+ripencc|GB|ipv6|2001:db8::|32|20200101|allocated
+some garbage line with no pipes at all
+|GB|asn|100|1|20200101|allocated
+ripencc|GB|asn|100|1|20200101
+ripencc|GB|asn|100|1|20200101|allocated|extra|fields|ok
+";
+        let mut map = HashMap::new();
+        parse_delegated_stats(text, &mut map);
+        // empty registry is kept (only CC matters), short lines dropped,
+        // extended lines with >7 fields still parsed
+        assert_eq!(map.get(&100).map(String::as_str), Some("GB"));
+        assert_eq!(map.len(), 1);
     }
 }

--- a/src/asinfo/mod.rs
+++ b/src/asinfo/mod.rs
@@ -481,7 +481,13 @@ fn fill_missing_asns_from_delegated_stats(
         filled
     );
 }
-
+/// Loads the ASN information map and returns it.
+///
+/// The core RIPE NCC `asn.txt` data (plus the RIR delegated-stats fill) is
+/// required: load failures propagate as `Err`. Optional enrichment datasets
+/// (as2org, population, hegemony, peeringdb) fail soft — a failed download or
+/// API error (e.g., PeeringDB rate limiting without `PEERINGDB_API_KEY`)
+/// logs a warning and proceeds with that dataset's fields left as `None`.
 pub fn get_asinfo_map(
     load_as2org: bool,
     load_population: bool,
@@ -512,25 +518,52 @@ pub fn get_asinfo_map(
 
     let as2org_utils = if load_as2org {
         info!("loading as2org data from CAIDA...");
-        Some(as2org::As2org::new(None)?)
+        match as2org::As2org::new(None) {
+            Ok(data) => Some(data),
+            Err(e) => {
+                warn!("failed to load as2org data, proceeding without it: {e}");
+                None
+            }
+        }
     } else {
         None
     };
     let population_utils = if load_population {
         info!("loading ASN population data from APNIC...");
-        Some(population::AsnPopulation::new()?)
+        match population::AsnPopulation::new() {
+            Ok(data) => Some(data),
+            Err(e) => {
+                warn!("failed to load population data, proceeding without it: {e}");
+                None
+            }
+        }
     } else {
         None
     };
     let hegemony_utils = if load_hegemony {
         info!("loading IIJ IHR hegemony score data from BGPKIT mirror...");
-        Some(hegemony::Hegemony::new()?)
+        match hegemony::Hegemony::new() {
+            Ok(data) => Some(data),
+            Err(e) => {
+                warn!("failed to load hegemony data, proceeding without it: {e}");
+                None
+            }
+        }
     } else {
         None
     };
     let peeringdb_utils = if load_peeringdb {
         info!("loading peeringdb data...");
-        Some(Peeringdb::new_networks_only()?)
+        match Peeringdb::new_networks_only() {
+            Ok(data) => Some(data),
+            Err(e) => {
+                warn!(
+                    "failed to load peeringdb data, proceeding without it: {e} \
+                     (hint: set PEERINGDB_API_KEY to avoid rate limiting)"
+                );
+                None
+            }
+        }
     } else {
         None
     };

--- a/src/asinfo/mod.rs
+++ b/src/asinfo/mod.rs
@@ -354,9 +354,10 @@ pub fn get_asinfo_map_cached() -> Result<HashMap<u32, AsInfo>> {
 /// Parse RIR delegated stats text (NRO format) into an ASN -> country code map.
 ///
 /// Record format: `registry|CC|type|start|value|date|status[|extensions]`.
-/// Only `asn` records with a real (non-empty, non-`*`) country code are kept;
-/// private-use ASN ranges (RFC 6996: 64512-65534 and 4200000000+) are excluded.
-/// Ranges are expanded per-ASN (`value` is a count).
+/// Only `asn` records with `allocated`/`assigned` status and a real (non-empty,
+/// non-`*`) country code are kept; private-use ASN ranges (RFC 6996:
+/// 64512-65534 and 4200000000+) are excluded. Ranges are expanded per-ASN
+/// (`value` is a count).
 fn parse_delegated_stats(text: &str, map: &mut HashMap<u32, String>) {
     for line in text.lines() {
         let line = line.trim();
@@ -365,6 +366,10 @@ fn parse_delegated_stats(text: &str, map: &mut HashMap<u32, String>) {
         }
         let parts: Vec<&str> = line.split('|').collect();
         if parts.len() < 7 || parts[2] != "asn" {
+            continue;
+        }
+        let status = parts[6].trim();
+        if status != "allocated" && status != "assigned" {
             continue;
         }
         let cc = parts[1].trim();
@@ -387,16 +392,54 @@ fn parse_delegated_stats(text: &str, map: &mut HashMap<u32, String>) {
     }
 }
 
+/// Look up optional enrichment data (as2org, population, hegemony, peeringdb)
+/// for an ASN from already-loaded datasets. Shared by the main `asn.txt` parse
+/// loop and the delegated-stats fill so both paths behave identically.
+#[allow(clippy::type_complexity)]
+fn lookup_enrichment(
+    asn: u32,
+    as2org_utils: Option<&as2org::As2org>,
+    population_utils: Option<&population::AsnPopulation>,
+    hegemony_utils: Option<&hegemony::Hegemony>,
+    peeringdb_utils: Option<&Peeringdb>,
+) -> (
+    Option<As2orgInfo>,
+    Option<AsnPopulationData>,
+    Option<HegemonyData>,
+    Option<Network>,
+) {
+    let as2org = as2org_utils.and_then(|as2org_data| {
+        as2org_data.get_as_info(asn).map(|info| As2orgInfo {
+            name: info.name.clone(),
+            country: info.country_code.clone(),
+            org_id: info.org_id.clone(),
+            org_name: info.org_name.clone(),
+        })
+    });
+    let population = population_utils.and_then(|p| p.get(asn));
+    let hegemony = hegemony_utils.and_then(|h| h.get_score(asn).cloned());
+    let peeringdb = peeringdb_utils.and_then(|h| h.get_network(asn).cloned());
+    (as2org, population, hegemony, peeringdb)
+}
+
 /// Fill ASNs missing from the RIPE NCC `asn.txt`-derived map using the five
 /// RIR delegated stats files (authoritative allocation data, updated daily).
 ///
 /// `asn.txt` lags behind new allocations by days to weeks; the delegated
 /// stats cover them. Synthesized entries carry the allocated country code and
-/// an `"UNKNOWN"` name (delegated stats do not include names), with all
-/// optional enrichment fields left as `None`.
+/// an `"UNKNOWN"` name (delegated stats do not include names). Optional
+/// enrichment fields (as2org, population, hegemony, peeringdb) are looked up
+/// from the already-loaded datasets, so `get_preferred_name()` can still
+/// resolve a real name for filled ASNs registered in PeeringDB/as2org.
 ///
 /// Best-effort: failures fetching individual files are logged and skipped.
-fn fill_missing_asns_from_delegated_stats(asnames_map: &mut HashMap<u32, AsInfo>) {
+fn fill_missing_asns_from_delegated_stats(
+    asnames_map: &mut HashMap<u32, AsInfo>,
+    as2org_utils: Option<&as2org::As2org>,
+    population_utils: Option<&population::AsnPopulation>,
+    hegemony_utils: Option<&hegemony::Hegemony>,
+    peeringdb_utils: Option<&Peeringdb>,
+) {
     let read_text = |url: &str| -> Result<String> {
         let mut text = String::new();
         oneio::get_reader(url)?.read_to_string(&mut text)?;
@@ -415,14 +458,21 @@ fn fill_missing_asns_from_delegated_stats(asnames_map: &mut HashMap<u32, AsInfo>
     for (asn, country) in delegated {
         asnames_map.entry(asn).or_insert_with(|| {
             filled += 1;
+            let (as2org, population, hegemony, peeringdb) = lookup_enrichment(
+                asn,
+                as2org_utils,
+                population_utils,
+                hegemony_utils,
+                peeringdb_utils,
+            );
             AsInfo {
                 asn,
                 name: "UNKNOWN".to_string(),
                 country,
-                as2org: None,
-                population: None,
-                hegemony: None,
-                peeringdb: None,
+                as2org,
+                population,
+                hegemony,
+                peeringdb,
             }
         });
     }
@@ -497,21 +547,13 @@ pub fn get_asinfo_map(
                 None => return None,
             };
             let asn = asn_str.parse::<u32>().unwrap();
-            let as2org = as2org_utils.as_ref().and_then(|as2org_data| {
-                as2org_data.get_as_info(asn).map(|info| As2orgInfo {
-                    name: info.name.clone(),
-                    country: info.country_code.clone(),
-                    org_id: info.org_id.clone(),
-                    org_name: info.org_name.clone(),
-                })
-            });
-            let population = population_utils.as_ref().and_then(|p| p.get(asn));
-            let hegemony = hegemony_utils
-                .as_ref()
-                .and_then(|h| h.get_score(asn).cloned());
-            let peeringdb = peeringdb_utils
-                .as_ref()
-                .and_then(|h| h.get_network(asn).cloned());
+            let (as2org, population, hegemony, peeringdb) = lookup_enrichment(
+                asn,
+                as2org_utils.as_ref(),
+                population_utils.as_ref(),
+                hegemony_utils.as_ref(),
+                peeringdb_utils.as_ref(),
+            );
             Some(AsInfo {
                 asn,
                 name: name_str.to_string(),
@@ -530,7 +572,13 @@ pub fn get_asinfo_map(
     }
 
     info!("filling ASNs missing from RIPE NCC asn.txt via RIR delegated stats...");
-    fill_missing_asns_from_delegated_stats(&mut asnames_map);
+    fill_missing_asns_from_delegated_stats(
+        &mut asnames_map,
+        as2org_utils.as_ref(),
+        population_utils.as_ref(),
+        hegemony_utils.as_ref(),
+        peeringdb_utils.as_ref(),
+    );
 
     Ok(asnames_map)
 }
@@ -701,6 +749,25 @@ arin|US|asn|123|notacount|20200101|allocated
         let mut map = HashMap::new();
         parse_delegated_stats(text, &mut map);
         assert!(map.is_empty());
+    }
+
+    #[test]
+    fn test_parse_delegated_stats_status_filter() {
+        // reserved/available records are dropped even when they carry a
+        // real-looking country code; only allocated/assigned are kept
+        let text = "\
+arin|US|asn|300000|1|20200101|reserved
+arin|US|asn|300001|1|20200101|available
+arin|US|asn|300002|1|20200101|allocated
+arin|US|asn|300003|1|20200101|assigned
+";
+        let mut map = HashMap::new();
+        parse_delegated_stats(text, &mut map);
+        assert!(!map.contains_key(&300000));
+        assert!(!map.contains_key(&300001));
+        assert_eq!(map.get(&300002).map(String::as_str), Some("US"));
+        assert_eq!(map.get(&300003).map(String::as_str), Some("US"));
+        assert_eq!(map.len(), 2);
     }
 
     #[test]


### PR DESCRIPTION
## Problem

RIPE NCC `asn.txt` (the primary source for `asinfo` names/countries) lags behind new allocations by days to weeks. Recently allocated ASNs are absent from `get_asinfo_map()` / `load_asinfo()`, producing missing entries downstream.

## Fix

`get_asinfo_map()` now fills ASNs missing from `asn.txt` using the five **RIR delegated stats files** — authoritative, daily-updated allocation records that do not lag:

* ARIN (extended), RIPE NCC, APNIC, LACNIC, AFRINIC
* Only `allocated`/`assigned` records used (reserved/available excluded, even with a CC)
* RFC 6996 private-use ranges excluded
* Filled entries: real country code, `name: "UNKNOWN"`, enrichment fields looked up from already-loaded datasets (as2org/peeringdb/population/hegemony) — `get_preferred_name()` resolves real names where registered
* Per-file failures warn-and-continue

**Live verification:** map grows 121,463 → 122,462 (+999). Of the filled ASNs, 186 have PeeringDB names and 527 have as2org entries.

## Also in this PR

* Optional enrichment datasets now **fail soft**: as2org/population/hegemony/peeringdb load or API errors (e.g., PeeringDB 429 without `PEERINGDB_API_KEY`) log a warning and proceed with `None` fields instead of failing the entire load. Core asn.txt errors still propagate.
* Shared `lookup_enrichment()` helper used by both the asn.txt parse loop and the delegated fill.

## No breaking changes

No new `AsInfo` fields, no signature changes, no schema changes. After release, bumping `bgpkit-commons` in `bgpkit/asninfo` propagates the fix to the data.bgpkit.com mirror with no generator code changes.

## Tests

6 parser unit tests (range expansion, status filter, reserved/private filtering, boundaries, case normalization, malformed lines). fmt/clippy/tests green; `test_basic_info` integration test passes.