### PR TITLE
feat(irr): add IRR data support with RPSL parsing and AS info enrichment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,16 @@ All notable changes to this project will be documented in this file.
   peeringdb) are looked up from the already-loaded datasets, so
   `get_preferred_name()` resolves real names for filled ASNs registered in
   PeeringDB/as2org. Fetch failures for individual files are logged and
-  files are logged and skipped (best-effort). No API or schema changes.
+  skipped (best-effort).
+* New source-faithful `irr` and `delegated` parsing APIs separate acquisition
+  and parsing from AsInfo enrichment policy. IRR records preserve attribute
+  order and unsupported object classes; explicit IRR source selections are
+  validated, while `with_irr()` loads every catalogued source.
+* `asinfo`: added `Minimum`, `Default`, and `Full` loading profiles. `Default`
+  matches the existing asninfo v1 sources; `Full` adds delegated statistics,
+  all IRR sources, and typed `Ipv4Net`/`Ipv6Net` route prefixes.
+* `asinfo`: absent enrichment fields are omitted during serialization, while
+  old cache records without `delegated` or `irr` remain deserializable.
 * `asinfo`: optional enrichment datasets (as2org, population, hegemony,
   peeringdb) in `get_asinfo_map()` now fail soft: a download or API error
   (e.g., PeeringDB rate limiting without `PEERINGDB_API_KEY`) logs a warning

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,9 @@ All notable changes to this project will be documented in this file.
 * `asinfo`: added `Minimum`, `Default`, and `Full` loading profiles. `Default`
   matches the existing asninfo v1 sources; `Full` adds delegated statistics,
   all IRR sources, and typed `Ipv4Net`/`Ipv6Net` route prefixes.
+* `asinfo`: `load_asinfo(bool, bool, bool, bool)` is deprecated in favor of
+  `load_asinfo_with_profile()` / `load_asinfo_with()`; the boolean form remains
+  as a compatibility shim with identical behavior.
 * `asinfo`: absent enrichment fields are omitted during serialization, while
   old cache records without `delegated` or `irr` remain deserializable.
 * `asinfo`: optional enrichment datasets (as2org, population, hegemony,

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,7 +47,8 @@ default = ["all"]
 
 # Module features
 irr = ["oneio", "rpsl-rs", "ipnet", "serde_json", "tracing"]
-asinfo = ["peeringdb", "irr", "oneio", "serde_json", "tracing", "chrono", "regex"]
+delegated = ["oneio", "tracing"]
+asinfo = ["peeringdb", "irr", "delegated", "oneio", "serde_json", "tracing", "chrono", "regex"]
 as2rel = ["oneio", "serde_json", "tracing"]
 bogons = ["oneio", "ipnet", "regex", "chrono"]
 countries = ["oneio"]
@@ -56,7 +57,7 @@ peeringdb = ["oneio", "serde_json", "tracing"]
 rpki = ["oneio", "ipnet", "ipnet-trie", "chrono", "tracing", "tar", "serde_json", "zstd", "bcder"]
 
 # Convenience feature to enable all modules
-all = ["asinfo", "as2rel", "bogons", "countries", "irr", "mrt_collectors", "peeringdb", "rpki"]
+all = ["asinfo", "as2rel", "bogons", "countries", "delegated", "irr", "mrt_collectors", "peeringdb", "rpki"]
 
 # Example configurations - specify required features for each example
 [[example]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,9 @@ oneio = { version = "0.24.0", optional = true, features = [
     "xz",
     "reqwest-gzip",
     "rustls",
+    "ftp",
 ] }
+rpsl-rs = { version = "3.0", optional = true }
 regex = { version = "1", optional = true }
 serde_json = { version = "1", optional = true }
 tracing = { version = "0.1", optional = true }
@@ -37,14 +39,15 @@ bcder = { version = "0.7", optional = true }
 [dev-dependencies]
 tracing-subscriber = "0.3"
 serde_json = "1"
-oneio = { version = "0.24.0", features = ["json", "xz", "reqwest-gzip", "rustls"] }
+oneio = { version = "0.24.0", features = ["json", "xz", "reqwest-gzip", "rustls", "ftp"] }
 
 
 [features]
 default = ["all"]
 
 # Module features
-asinfo = ["peeringdb", "oneio", "serde_json", "tracing", "chrono", "regex"]
+irr = ["oneio", "rpsl-rs", "ipnet", "serde_json", "tracing"]
+asinfo = ["peeringdb", "irr", "oneio", "serde_json", "tracing", "chrono", "regex"]
 as2rel = ["oneio", "serde_json", "tracing"]
 bogons = ["oneio", "ipnet", "regex", "chrono"]
 countries = ["oneio"]
@@ -53,7 +56,7 @@ peeringdb = ["oneio", "serde_json", "tracing"]
 rpki = ["oneio", "ipnet", "ipnet-trie", "chrono", "tracing", "tar", "serde_json", "zstd", "bcder"]
 
 # Convenience feature to enable all modules
-all = ["asinfo", "as2rel", "bogons", "countries", "mrt_collectors", "peeringdb", "rpki"]
+all = ["asinfo", "as2rel", "bogons", "countries", "irr", "mrt_collectors", "peeringdb", "rpki"]
 
 # Example configurations - specify required features for each example
 [[example]]
@@ -75,6 +78,14 @@ required-features = ["rpki"]
 [[example]]
 name = "rpkispools"
 required-features = ["rpki"]
+
+[[example]]
+name = "gen_full_jsonl"
+required-features = ["asinfo"]
+
+[[example]]
+name = "bench_asinfo"
+required-features = ["asinfo"]
 
 [lints.clippy]
 uninlined_format_args = "allow"

--- a/NEXTGEN_INTERFACE_SPEC.md
+++ b/NEXTGEN_INTERFACE_SPEC.md
@@ -1,0 +1,352 @@
+# BGPKIT Commons Source and AsInfo Interface Specification
+
+**Status:** Approved and implemented on this branch
+**Baseline:** PR #39 head `e3f9857` (`feat/irr-data-support`)
+
+## 1. Scope
+
+This refactor has three goals:
+
+1. Separate source fetching/parsing from data serving and enrichment. Source modules return source records without choosing preferred values or modifying another source's data.
+2. Add two source-scoped fields, `delegated` and `irr`, to `AsInfo`. Do not otherwise redesign the `AsInfo` record, and omit enrichment fields from serialized output when they are absent.
+3. Expose three AsInfo loading profiles: `Minimum`, `Default`, and `Full`.
+
+This is a focused cleanup of PR #39. It is not a crate-wide snapshot, provenance, transport, caching, async, or error-model redesign.
+
+## 2. Two layers
+
+### 2.1 Source layer
+
+A source module is responsible for:
+
+- describing known sources and dump URLs;
+- fetching a selected source artifact;
+- parsing a caller-provided reader;
+- returning records that preserve the source's values;
+- reporting fetch and parse errors.
+
+A source module must not:
+
+- pick a preferred value across registries;
+- merge one registry's object into another registry's object;
+- replace an AsInfo name or country;
+- silently ignore an explicitly requested source;
+- serialize an application-specific output format.
+
+Fetching and parsing are separate entry points. Parsing must work with a local reader and must not perform network access.
+
+### 2.2 Serving/product layer
+
+`asinfo` is the serving and enrichment layer. It chooses which source modules to load, indexes their records by ASN, and constructs `AsInfo` values according to a profile.
+
+All cross-source policy stays in `asinfo`, including:
+
+- which sources a profile enables;
+- how IRR records are grouped by ASN and registry;
+- how delegated-statistics records are projected onto an ASN;
+- whether route and route6 objects are included;
+- existing preferred-name behavior.
+
+The existing `BgpkitCommons` façade and `AsInfoBuilder` remain. This refactor does not introduce a new universal `Snapshot` API.
+
+## 3. IRR source API
+
+PR #39 already provides the source catalog, dump fetching, RPSL parsing, and typed IRR objects. The refactor should preserve that work while making the source/product boundary explicit.
+
+### 3.1 Parsing
+
+The canonical parser accepts a reader and yields source records:
+
+```rust
+pub fn parse_reader<R: Read>(
+    reader: R,
+    format: DumpFormat,
+) -> impl Iterator<Item = Result<IrrRecord, IrrError>>;
+```
+
+`IrrRecord` represents one RPSL object without AsInfo policy:
+
+```rust
+pub struct IrrRecord {
+    pub object_type: String,
+    pub attributes: Vec<IrrAttribute>,
+}
+
+pub struct IrrAttribute {
+    pub name: String,
+    pub value: String,
+}
+```
+
+Requirements:
+
+- preserve object order;
+- preserve attribute order and repeated attributes;
+- retain unsupported object classes instead of dropping them;
+- return malformed objects as iterator errors instead of only logging and skipping them;
+- preserve the RPSL `source:` attribute as an ordinary source value;
+- do not attach AsInfo meaning to any attribute.
+
+The existing PR #39 types (`AutNum`, `Route`, `AsSet`, `RouteSet`, `Mntner`, and `Organisation`) become typed conversions or views over `IrrRecord`. Existing callback APIs may remain as compatibility wrappers.
+
+Exact original bytes and a crate-wide provenance framework are not required by this refactor.
+
+### 3.2 Fetching
+
+Fetching selects and opens a dump; parsing remains reusable independently:
+
+```rust
+pub fn fetch(source: &IrrSource, object_type: IrrObjectType) -> Result<IrrReader>;
+```
+
+Requirements:
+
+- the caller explicitly selects the source and object type;
+- an unknown requested source returns an error;
+- fetch does not merge registries;
+- fetch does not create or modify `AsInfo`;
+- whole-database dumps are fetched once when several object types use the same URL.
+
+The current source catalog and HTTP/FTP support from PR #39 remain in scope. No new async API or generic transport framework is required.
+
+### 3.3 Source selection
+
+Keep the useful presets:
+
+- `all_sources()` — every known source and the default used by `with_irr()` and `Full`;
+- `default_sources()` — an optional curated subset for callers that explicitly choose it;
+- explicit source selection for callers that need a subset.
+
+Explicit names must be validated. A typo must not silently produce an empty selection.
+
+The AsInfo builder exposes both default-all and explicit-subset loading:
+
+```rust
+// All catalogued IRR sources.
+AsInfoBuilder::new().with_irr();
+
+// A caller-selected subset; invalid names return an error.
+let sources = IrrSourceConfig::only(&["RIPE", "RADB"])?;
+AsInfoBuilder::new().with_irr_sources(sources);
+```
+
+Source selection changes which registries are fetched; it does not establish a preference or merge records across registries.
+
+## 4. Delegated-statistics source API
+
+PR #39 currently fetches and parses RIR delegated-statistics files inside `asinfo`. Move that work into a small `delegated` source module so it can be used without AsInfo.
+
+```rust
+pub fn parse_reader<R: Read>(reader: R) -> impl Iterator<Item = Result<DelegatedRecord, DelegatedError>>;
+
+pub struct DelegatedRecord {
+    pub registry: String,
+    pub country: String,
+    pub record_type: String,
+    pub start: String,
+    pub value: String,
+    pub date: String,
+    pub status: String,
+}
+```
+
+The source parser returns delegated records as published. It does not fill missing ASNs, replace names or countries, or decide which statuses belong in AsInfo. Fetching the five RIR files is also exposed by the `delegated` module.
+
+Filtering to ASN allocation records and constructing `DelegatedInfo` happens in the AsInfo serving layer.
+
+## 5. AsInfo changes
+
+Keep the existing `AsInfo` fields and add `delegated` and `irr` at the same level:
+
+```rust
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AsInfo {
+    pub asn: u32,
+    pub name: String,
+    pub country: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub as2org: Option<As2orgInfo>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub population: Option<AsnPopulationData>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub hegemony: Option<HegemonyData>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub peeringdb: Option<Network>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub delegated: Option<DelegatedInfo>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub irr: Vec<IrrAsnInfo>,
+}
+```
+
+Serde defaults are required so existing cached JSON without `delegated` or `irr` remains readable. This fixes the current PR #39 failure: `missing field 'irr'`.
+
+Serialization includes only data that exists for that ASN:
+
+- `Minimum` records contain only `asn`, `name`, and `country`;
+- optional enrichment fields are omitted when their value is `None`;
+- `delegated` is omitted when it is `None`;
+- `irr` is omitted when it is empty;
+- `null` and empty placeholder fields are not emitted.
+
+This rule applies per ASN. Even when a profile loads a source globally, an ASN with no record from that source omits the corresponding field.
+
+`IrrAsnInfo` remains source-scoped:
+
+```rust
+pub struct IrrAsnInfo {
+    pub as_name: String,
+    pub descr: Vec<String>,
+    pub source: String,
+    pub mnt_by: Vec<String>,
+    pub route_prefixes: Vec<Ipv4Net>,
+    pub route6_prefixes: Vec<Ipv6Net>,
+    pub member_of_sets: Vec<String>,
+}
+```
+
+Prefixes are stored as `Ipv4Net` and `Ipv6Net`, not `String`. This avoids repeated heap-allocated CIDR strings, reduces in-memory size, and gives callers typed prefix values. With the existing `ipnet` Serde support, JSON output remains human-readable CIDR strings.
+
+`DelegatedInfo` remains source-scoped:
+
+```rust
+pub struct DelegatedInfo {
+    pub registry: String,
+    pub country: String,
+    pub date: String,
+    pub status: String,
+}
+```
+
+There may be multiple entries for an ASN because different IRR registries can publish different values. The library does not choose a trusted IRR registry or overwrite the existing `name`, `country`, or other source fields with IRR values.
+
+Delegated data is likewise retained in `delegated`; it does not overwrite the base `name` or `country` fields.
+
+## 6. AsInfo profiles
+
+Keep the existing profile names; no profile-version framework is needed.
+
+```rust
+pub enum AsInfoProfile {
+    Minimum,
+    #[default]
+    Default,
+    Full,
+}
+```
+
+The profiles are:
+
+| Profile | Sources |
+|---|---|
+| `Minimum` | `asn.txt` only: ASN, name, and country |
+| `Default` | `asn.txt` + CAIDA AS2Org + APNIC population + IHR hegemony + PeeringDB |
+| `Full` | Everything in `Default` + RIR delegated statistics + IRR from every source returned by `all_sources()`, including route and route6 prefixes |
+
+`Default` is grounded in the current normal, non-simplified `../asninfo` v1 path, which calls:
+
+```rust
+commons.load_asinfo(true, true, true, true)
+```
+
+The four arguments enable AS2Org, population, hegemony, and PeeringDB. The `asn.txt` base is always loaded.
+
+The `asninfo --simplified` behavior is an application output mode and does not define an additional library profile.
+
+Profile mapping remains straightforward:
+
+```rust
+match profile {
+    AsInfoProfile::Minimum => AsInfoBuilder::new(),
+    AsInfoProfile::Default => AsInfoBuilder::new()
+        .with_as2org()
+        .with_population()
+        .with_hegemony()
+        .with_peeringdb(),
+    AsInfoProfile::Full => AsInfoBuilder::new()
+        .with_as2org()
+        .with_population()
+        .with_hegemony()
+        .with_peeringdb()
+        .with_delegated()
+        .with_irr()
+        .with_irr_route_prefixes(),
+}
+```
+
+`AsInfoBuilder` remains available for custom combinations and explicit IRR source selection.
+
+`with_irr()` means all available IRR sources. `with_irr_sources(config)` uses exactly the caller's validated subset.
+
+## 7. Cargo features
+
+Keep the feature model simple:
+
+- `irr` enables IRR records, parsing, source catalog, and fetching;
+- `delegated` enables delegated-statistics records, parsing, and fetching;
+- `asinfo` may depend on `irr` and `delegated` because it serves both enrichments;
+- no `irr-parse`, `irr-fetch`, `asinfo-irr`, profile-specific, or legacy feature matrix is required for this refactor.
+
+The architectural separation is between module responsibilities and APIs, not a requirement to create a Cargo feature for every boundary.
+
+## 8. Compatibility
+
+- Existing `AsInfo` JSON must deserialize with `delegated: None` and `irr: Vec::new()` when the fields are absent.
+- Existing JSON containing `null` for optional enrichment fields must continue to deserialize.
+- New serialization omits absent optional fields and empty `irr` arrays instead of writing `null` or `[]`.
+- Existing `load_asinfo(bool, bool, bool, bool)` remains as a compatibility entry point and maps to the same behavior as before.
+- Existing `AsInfoBuilder` methods remain.
+- Existing IRR callback parsing APIs may remain as wrappers.
+- `BgpkitCommons` remains supported; making it legacy or removing it is out of scope.
+- No other module is redesigned in this change.
+
+## 9. Tests
+
+Required deterministic tests:
+
+1. Parse a local reader without network access.
+2. Preserve repeated attributes and their order.
+3. Return an unsupported RPSL object as `IrrRecord`.
+4. Return a malformed record as an error.
+5. Reject an unknown explicitly requested IRR source.
+6. `with_irr()` resolves to every source in `all_sources()`.
+7. An explicit IRR subset fetches only the selected sources.
+8. Store route and route6 prefixes as `Ipv4Net` and `Ipv6Net` and serialize them as CIDR strings.
+9. Parse delegated statistics from a local reader without AsInfo.
+10. Deserialize old `AsInfo` JSON without `delegated` or `irr` and obtain `None` and an empty vector.
+11. Deserialize old `AsInfo` JSON containing `null` optional fields.
+12. Serialize a `Minimum` record with only `asn`, `name`, and `country` keys.
+13. Omit each `None` enrichment and omit an empty `irr` vector.
+14. `Minimum` enables no optional enrichment.
+15. `Default` enables exactly AS2Org, population, hegemony, and PeeringDB.
+16. `Full` enables everything in `Default` plus delegated statistics, all IRR sources, and route prefixes.
+17. Delegated and IRR enrichment never overwrite `AsInfo.name` or `AsInfo.country`.
+
+Live IRR download tests remain ignored network tests; local fixtures are the normal merge gate.
+
+## 10. Implementation sequence
+
+1. Refactor PR #39's IRR parser to return unopinionated `IrrRecord` values while retaining typed compatibility conversions.
+2. Make all catalogued IRR sources the default, validate explicit source subsets, and avoid duplicate whole-database fetches.
+3. Move delegated-statistics fetching/parsing from `asinfo` into an unopinionated `delegated` module.
+4. Keep `AsInfo.delegated` and `AsInfo.irr` as sibling source-scoped fields, add backward-compatible Serde defaults, and omit absent enrichment fields during serialization.
+5. Make `Minimum`, `Default`, and `Full` match §6 exactly.
+6. Add local parser, profile, and old-cache compatibility tests.
+7. Update examples and documentation.
+
+## 11. Acceptance criteria
+
+The refactor is complete when:
+
+- IRR fetching/parsing can be used directly without AsInfo;
+- delegated-statistics fetching/parsing can be used directly without AsInfo;
+- direct IRR APIs return source records without enrichment policy;
+- direct delegated APIs return source records without enrichment policy;
+- `AsInfo` adds backward-compatible sibling `delegated` and `irr` fields;
+- IRR prefixes are stored as typed `Ipv4Net` and `Ipv6Net` values rather than strings;
+- users can select an exact IRR source subset, while `with_irr()` and `Full` load all catalogued sources by default;
+- serialized AsInfo records contain no `null` enrichment fields or empty `irr` arrays;
+- `Default` reproduces the current normal `asninfo` v1 source selection;
+- `Full` adds delegated and all supported IRR enrichment;
+- old AsInfo cache data still loads;
+- formatting, Clippy, deterministic tests, and all-feature tests pass.

--- a/examples/as2org.rs
+++ b/examples/as2org.rs
@@ -5,7 +5,8 @@ fn main() {
     tracing_subscriber::fmt::init();
     info!("loading asn info data ...");
     let mut commons = bgpkit_commons::BgpkitCommons::new();
-    commons.load_asinfo(true, false, false, false).unwrap();
+    let builder = commons.asinfo_builder().with_as2org();
+    commons.load_asinfo_with(builder).unwrap();
     commons.load_countries().unwrap();
     let as_info_map = commons.asinfo_all().unwrap();
 

--- a/examples/bench_asinfo.rs
+++ b/examples/bench_asinfo.rs
@@ -39,7 +39,7 @@ fn main() {
                 let mut c = BgpkitCommons::new();
                 let b = c
                     .asinfo_builder()
-                    .with_irr_sources(IrrSourceConfig::sources(&[*src]).unwrap());
+                    .with_irr_sources(IrrSourceConfig::only(&[*src]).unwrap());
                 c.load_asinfo_with(b).unwrap();
             },
         );

--- a/examples/bench_asinfo.rs
+++ b/examples/bench_asinfo.rs
@@ -39,14 +39,14 @@ fn main() {
                 let mut c = BgpkitCommons::new();
                 let b = c
                     .asinfo_builder()
-                    .with_irr_sources(IrrSourceConfig::sources(&[*src]));
+                    .with_irr_sources(IrrSourceConfig::sources(&[*src]).unwrap());
                 c.load_asinfo_with(b).unwrap();
             },
         );
     }
 
-    // 4. All IRR default sources
-    time_it("IRR all defaults (7 sources):", || {
+    // 4. All catalogued IRR sources
+    time_it("IRR all sources:", || {
         let mut c = BgpkitCommons::new();
         let b = c.asinfo_builder().with_irr();
         c.load_asinfo_with(b).unwrap();

--- a/examples/bench_asinfo.rs
+++ b/examples/bench_asinfo.rs
@@ -1,0 +1,78 @@
+//! Benchmark each asinfo data source individually.
+use bgpkit_commons::BgpkitCommons;
+use bgpkit_commons::asinfo::IrrSourceConfig;
+use std::time::Instant;
+
+fn time_it<F: FnOnce()>(label: &str, f: F) {
+    let start = Instant::now();
+    f();
+    let elapsed = start.elapsed();
+    eprintln!("{label:50} {elapsed:>8.1?}");
+}
+
+fn main() {
+    tracing_subscriber::fmt::init();
+
+    eprintln!("=== Individual data source timing ===\n");
+
+    // 1. Core asn.txt only
+    time_it("asn.txt only:", || {
+        let mut c = BgpkitCommons::new();
+        c.load_asinfo_with_profile(bgpkit_commons::asinfo::AsInfoProfile::Minimum)
+            .unwrap();
+    });
+
+    // 2. + delegated stats
+    time_it("asn.txt + delegated:", || {
+        let mut c = BgpkitCommons::new();
+        let b = c.asinfo_builder().with_delegated();
+        c.load_asinfo_with(b).unwrap();
+    });
+
+    // 3. IRR sources individually
+    for src in &[
+        "RIPE", "APNIC", "ARIN", "LACNIC", "AFRINIC", "NTTCOM", "RADB",
+    ] {
+        time_it(
+            &format!("IRR source: {src} (aut-num+route+route6+as-set):"),
+            || {
+                let mut c = BgpkitCommons::new();
+                let b = c
+                    .asinfo_builder()
+                    .with_irr_sources(IrrSourceConfig::sources(&[*src]));
+                c.load_asinfo_with(b).unwrap();
+            },
+        );
+    }
+
+    // 4. All IRR default sources
+    time_it("IRR all defaults (7 sources):", || {
+        let mut c = BgpkitCommons::new();
+        let b = c.asinfo_builder().with_irr();
+        c.load_asinfo_with(b).unwrap();
+    });
+
+    // 5. Full load
+    time_it(
+        "FULL (as2org+population+hegemony+pdb+delegated+irr):",
+        || {
+            let mut c = BgpkitCommons::new();
+            c.load_asinfo_with_profile(bgpkit_commons::asinfo::AsInfoProfile::Full)
+                .unwrap();
+        },
+    );
+
+    eprintln!("\n=== Memory stats ===");
+    // Print the map size for the full load
+    let mut c = BgpkitCommons::new();
+    c.load_asinfo_with_profile(bgpkit_commons::asinfo::AsInfoProfile::Full)
+        .unwrap();
+    let all = c.asinfo_all().unwrap();
+    let irr_count = all.values().filter(|i| !i.irr.is_empty()).count();
+    let del_count = all.values().filter(|i| i.delegated.is_some()).count();
+    let unknown_count = all.values().filter(|i| i.name == "UNKNOWN").count();
+    eprintln!("Total ASNs: {}", all.len());
+    eprintln!("ASNs with IRR data: {irr_count}");
+    eprintln!("ASNs with delegated data: {del_count}");
+    eprintln!("ASNs still UNKNOWN: {unknown_count}");
+}

--- a/examples/gen_full_jsonl.rs
+++ b/examples/gen_full_jsonl.rs
@@ -1,0 +1,67 @@
+//! Generate JSONL output for size comparison: with and without route prefixes.
+use bgpkit_commons::BgpkitCommons;
+use bgpkit_commons::asinfo::AsInfoBuilder;
+use std::io::Write;
+
+fn main() {
+    tracing_subscriber::fmt::init();
+
+    // Variant 1: full IRR but WITHOUT route prefixes (default)
+    {
+        eprintln!("Loading WITHOUT route prefixes...");
+        let mut commons = BgpkitCommons::new();
+        let _builder = AsInfoBuilder::new()
+            .with_as2org()
+            .with_population()
+            .with_hegemony()
+            .with_peeringdb()
+            .with_delegated()
+            .with_irr();
+        commons
+            .load_asinfo_with_profile(bgpkit_commons::asinfo::AsInfoProfile::Full)
+            .unwrap();
+
+        let all = commons.asinfo_all().unwrap();
+        let mut f = std::fs::File::create("/tmp/asinfo_no_routes.jsonl").unwrap();
+        for asn in all
+            .keys()
+            .collect::<std::collections::BTreeSet<_>>()
+            .into_iter()
+        {
+            let json = serde_json::to_string(&all[asn]).unwrap();
+            writeln!(f, "{json}").unwrap();
+        }
+        drop(f);
+        eprintln!("Written {} ASNs (no routes)", all.len());
+    }
+
+    // Variant 2: full IRR WITH route prefixes
+    {
+        eprintln!("Loading WITH route prefixes...");
+        let mut commons = BgpkitCommons::new();
+        let _builder = AsInfoBuilder::new()
+            .with_as2org()
+            .with_population()
+            .with_hegemony()
+            .with_peeringdb()
+            .with_delegated()
+            .with_irr()
+            .with_irr_route_prefixes();
+        commons
+            .load_asinfo_with_profile(bgpkit_commons::asinfo::AsInfoProfile::Full)
+            .unwrap();
+
+        let all = commons.asinfo_all().unwrap();
+        let mut f = std::fs::File::create("/tmp/asinfo_with_routes.jsonl").unwrap();
+        for asn in all
+            .keys()
+            .collect::<std::collections::BTreeSet<_>>()
+            .into_iter()
+        {
+            let json = serde_json::to_string(&all[asn]).unwrap();
+            writeln!(f, "{json}").unwrap();
+        }
+        drop(f);
+        eprintln!("Written {} ASNs (with routes)", all.len());
+    }
+}

--- a/examples/gen_full_jsonl.rs
+++ b/examples/gen_full_jsonl.rs
@@ -9,17 +9,15 @@ fn main() {
     // Variant 1: full IRR but WITHOUT route prefixes (default)
     {
         eprintln!("Loading WITHOUT route prefixes...");
-        let mut commons = BgpkitCommons::new();
-        let _builder = AsInfoBuilder::new()
+        let builder = AsInfoBuilder::new()
             .with_as2org()
             .with_population()
             .with_hegemony()
             .with_peeringdb()
             .with_delegated()
             .with_irr();
-        commons
-            .load_asinfo_with_profile(bgpkit_commons::asinfo::AsInfoProfile::Full)
-            .unwrap();
+        let mut commons = BgpkitCommons::new();
+        commons.load_asinfo_with(builder).unwrap();
 
         let all = commons.asinfo_all().unwrap();
         let mut f = std::fs::File::create("/tmp/asinfo_no_routes.jsonl").unwrap();
@@ -38,8 +36,7 @@ fn main() {
     // Variant 2: full IRR WITH route prefixes
     {
         eprintln!("Loading WITH route prefixes...");
-        let mut commons = BgpkitCommons::new();
-        let _builder = AsInfoBuilder::new()
+        let builder = AsInfoBuilder::new()
             .with_as2org()
             .with_population()
             .with_hegemony()
@@ -47,9 +44,8 @@ fn main() {
             .with_delegated()
             .with_irr()
             .with_irr_route_prefixes();
-        commons
-            .load_asinfo_with_profile(bgpkit_commons::asinfo::AsInfoProfile::Full)
-            .unwrap();
+        let mut commons = BgpkitCommons::new();
+        commons.load_asinfo_with(builder).unwrap();
 
         let all = commons.asinfo_all().unwrap();
         let mut f = std::fs::File::create("/tmp/asinfo_with_routes.jsonl").unwrap();

--- a/src/asinfo/mod.rs
+++ b/src/asinfo/mod.rs
@@ -817,7 +817,11 @@ fn enrich_from_irr(
                                 entry.mnt_by = mnt.clone();
                             }
                         }
-                        IrrObject::Route(r) => {
+                        // Route/route6 prefixes are collected only when
+                        // explicitly enabled. WholeDb dumps still download once
+                        // (URL dedup above) but route objects are skipped here
+                        // in the default no-prefix mode.
+                        IrrObject::Route(r) if collect_route_prefixes => {
                             let entry = source_map.entry(r.origin).or_default();
                             if entry.source.is_empty() {
                                 entry.source = r.source.clone();
@@ -826,7 +830,7 @@ fn enrich_from_irr(
                                 entry.route_prefixes.push(prefix);
                             }
                         }
-                        IrrObject::Route6(r) => {
+                        IrrObject::Route6(r) if collect_route_prefixes => {
                             let entry = source_map.entry(r.origin).or_default();
                             if entry.source.is_empty() {
                                 entry.source = r.source.clone();

--- a/src/asinfo/mod.rs
+++ b/src/asinfo/mod.rs
@@ -219,7 +219,7 @@ const BGPKIT_ASNINFO_URL: &str = "https://data.bgpkit.com/commons/asinfo.jsonl";
 /// use bgpkit_commons::asinfo::IrrSourceConfig;
 ///
 /// // Only RIPE + RADB
-/// let config = IrrSourceConfig::sources(&["RIPE", "RADB"]).unwrap();
+/// let config = IrrSourceConfig::only(&["RIPE", "RADB"]).unwrap();
 /// let asinfo = AsInfoBuilder::new()
 ///     .with_irr_sources(config)
 ///     .build()
@@ -227,14 +227,25 @@ const BGPKIT_ASNINFO_URL: &str = "https://data.bgpkit.com/commons/asinfo.jsonl";
 /// ```
 #[derive(Debug, Clone, Default)]
 pub struct IrrSourceConfig {
-    /// Registry names to fetch (e.g. `["RIPE", "RADB"]`).
-    /// If empty, uses every catalogued source.
-    pub sources: Vec<String>,
+    /// Registry names to fetch. Empty is reserved for [`Self::all`].
+    sources: Vec<String>,
 }
 
 impl IrrSourceConfig {
-    /// Create a config that fetches only the named sources.
+    /// Compatibility alias for [`Self::only`].
     pub fn sources(names: &[&str]) -> Result<Self> {
+        Self::only(names)
+    }
+
+    /// Create a config that fetches exactly the named sources.
+    pub fn only(names: &[&str]) -> Result<Self> {
+        if names.is_empty() {
+            return Err(BgpkitCommonsError::invalid_format(
+                "IRR source selection",
+                "[]",
+                "explicit source selection must not be empty",
+            ));
+        }
         let selected = crate::irr::sources_by_name(names)?;
         Ok(Self {
             sources: selected
@@ -348,7 +359,7 @@ impl AsInfoProfile {
 /// use bgpkit_commons::asinfo::IrrSourceConfig;
 ///
 /// let asinfo = AsInfoBuilder::new()
-///     .with_irr_sources(IrrSourceConfig::sources(&["RIPE", "RADB"]).unwrap())
+///     .with_irr_sources(IrrSourceConfig::only(&["RIPE", "RADB"]).unwrap())
 ///     .build()
 ///     .unwrap();
 /// ```
@@ -415,7 +426,7 @@ impl AsInfoBuilder {
     /// use bgpkit_commons::asinfo::{AsInfoBuilder, IrrSourceConfig};
     ///
     /// let asinfo = AsInfoBuilder::new()
-    ///     .with_irr_sources(IrrSourceConfig::sources(&["RIPE", "RADB"]).unwrap())
+    ///     .with_irr_sources(IrrSourceConfig::only(&["RIPE", "RADB"]).unwrap())
     ///     .build()
     ///     .unwrap();
     /// ```
@@ -435,7 +446,7 @@ impl AsInfoBuilder {
         self
     }
 
-    /// Enable all optional data sources with default IRR source set.
+    /// Enable all optional data, including route prefixes from every IRR source.
     pub fn with_all(mut self) -> Self {
         self.load_as2org = true;
         self.load_population = true;
@@ -443,6 +454,8 @@ impl AsInfoBuilder {
         self.load_peeringdb = true;
         self.load_delegated = true;
         self.load_irr = true;
+        self.irr_config = IrrSourceConfig::all();
+        self.irr_route_prefixes = true;
         self
     }
 
@@ -1318,10 +1331,16 @@ ripencc|GB|asn|100|1|20200101|allocated|extra|fields|ok
         assert!(full.load_irr);
         assert!(full.irr_route_prefixes);
         assert_eq!(full.irr_sources.len(), crate::irr::all_sources().len());
+
+        let all = AsInfoBuilder::new().with_all().config().unwrap();
+        assert!(all.irr_route_prefixes);
+        assert_eq!(all.irr_sources.len(), crate::irr::all_sources().len());
     }
 
     #[test]
     fn test_custom_irr_sources_are_validated() {
+        assert!(IrrSourceConfig::only(&[]).is_err());
+        assert!(IrrSourceConfig::sources(&[]).is_err());
         assert!(IrrSourceConfig::sources(&["RIPE", "NOT-A-REGISTRY"]).is_err());
 
         let selected = IrrSourceConfig::sources(&["RIPE", "RADB"]).unwrap();

--- a/src/asinfo/mod.rs
+++ b/src/asinfo/mod.rs
@@ -3,8 +3,10 @@
 //! # Data source
 //!
 //! - RIPE NCC asinfo: <https://ftp.ripe.net/ripe/asnames/asn.txt>
-//! - RIR delegated stats (fallback fill for ASNs missing from `asn.txt`):
+//! - RIR delegated stats (authoritative allocation records, attached to every ASN):
 //!   <https://www.nro.net/about/rirs/statistics/>
+//! - IRR `aut-num`, `route`/`route6` objects (per-source arrays for every ASN
+//!   with IRR registrations): RIPE, APNIC, ARIN, LACNIC, AFRINIC, NTTCOM, RADB
 //! - (Optional) CAIDA as-to-organization mapping: <https://www.caida.org/catalog/datasets/as-organizations/>
 //! - (Optional) APNIC AS population data: <https://stats.labs.apnic.net/cgi-bin/aspop>
 //! - (Optional) IIJ IHR Hegemony data: <https://ihr-archive.iijlab.net/>
@@ -22,6 +24,8 @@
 //!     pub as2org: Option<As2orgInfo>,
 //!     pub population: Option<AsnPopulationData>,
 //!     pub hegemony: Option<HegemonyData>,
+//!     pub irr: Vec<IrrAsnInfo>,
+//!     pub delegated: Option<DelegatedInfo>,
 //! }
 //! #[derive(Debug, Clone, Serialize, Deserialize)]
 //! pub struct As2orgInfo {
@@ -56,7 +60,7 @@
 //! use bgpkit_commons::BgpkitCommons;
 //!
 //! let mut bgpkit = BgpkitCommons::new();
-//! bgpkit.load_asinfo(false, false, false, false).unwrap();
+//! bgpkit.load_asinfo_with_profile(Default::default()).unwrap();
 //! let asinfo = bgpkit.asinfo_get(3333).unwrap().unwrap();
 //! assert_eq!(asinfo.name, "RIPE-NCC-AS Reseaux IP Europeens Network Coordination Centre (RIPE NCC)");
 //! ```
@@ -104,7 +108,7 @@
 //! use bgpkit_commons::BgpkitCommons;
 //!
 //! let mut bgpkit = BgpkitCommons::new();
-//! bgpkit.load_asinfo(true, false, false, false).unwrap();
+//! bgpkit.load_asinfo_with(bgpkit.asinfo_builder().with_as2org()).unwrap();
 //! let are_siblings = bgpkit.asinfo_are_siblings(3333, 3334).unwrap();
 //! ```
 
@@ -125,6 +129,52 @@ use tracing::{info, warn};
 pub use hegemony::HegemonyData;
 pub use population::AsnPopulationData;
 
+/// RIR delegated-stats data for a single ASN.
+///
+/// Sourced from the five RIR delegated stats files (NRO format). These are
+/// authoritative allocation records, updated daily. For each ASN, the
+/// registry that allocated it, the allocation date, status, and country
+/// code are recorded.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct DelegatedInfo {
+    /// The RIR that allocated/assigned this ASN (e.g. `"ripencc"`, `"arin"`).
+    pub registry: String,
+    /// The ISO 3166-1 alpha-2 country code (uppercased).
+    pub country: String,
+    /// The allocation/assignment date (as-is from the record, format: `YYYYMMDD`).
+    pub date: String,
+    /// The allocation status (`"allocated"` or `"assigned"`).
+    pub status: String,
+}
+
+/// IRR data for a single ASN from a single registry source.
+///
+/// Each entry corresponds to one IRR registry's view of this ASN. An ASN may
+/// have entries from multiple registries (e.g. both RIPE and RADB) — the
+/// `irr` field on [`AsInfo`] is a `Vec<IrrAsnInfo>` so callers can pick which
+/// source(s) to trust.
+///
+/// Provenance is preserved via `source` (the registry name from the RPSL
+/// `source:` attribute). IRR data is self-registered; trust varies by
+/// registry authorization model.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct IrrAsnInfo {
+    /// The `as-name` attribute from the IRR `aut-num` object.
+    pub as_name: String,
+    /// The `descr` attribute(s), if any.
+    pub descr: Vec<String>,
+    /// The `source:` attribute — which IRR registry published this object.
+    pub source: String,
+    /// The `mnt-by` attribute(s) — maintainers controlling this object.
+    pub mnt_by: Vec<String>,
+    /// Registered IPv4 prefixes from `route` objects with this ASN as origin.
+    pub route_prefixes: Vec<String>,
+    /// Registered IPv6 prefixes from `route6` objects with this ASN as origin.
+    pub route6_prefixes: Vec<String>,
+    /// AS-set names that contain this ASN as a direct member.
+    pub member_of_sets: Vec<String>,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct AsInfo {
     pub asn: u32,
@@ -134,6 +184,11 @@ pub struct AsInfo {
     pub population: Option<AsnPopulationData>,
     pub hegemony: Option<HegemonyData>,
     pub peeringdb: Option<Network>,
+    /// RIR delegated-stats allocation data. Present for every allocated ASN.
+    pub delegated: Option<DelegatedInfo>,
+    /// IRR data per registry source. Empty if the ASN has no IRR registrations.
+    /// Multiple sources may have data; callers choose which to trust.
+    pub irr: Vec<IrrAsnInfo>,
 }
 
 impl AsInfo {
@@ -186,7 +241,124 @@ const RIR_DELEGATED_STATS_URLS: &[&str] = &[
     "https://ftp.afrinic.net/pub/stats/afrinic/delegated-afrinic-latest",
 ];
 
+/// Configuration for which IRR sources to fetch.
+///
+/// By default, `with_irr()` uses the default source set (5 RIRs + NTTCOM + RADB).
+/// For finer control, use `with_irr_sources()` to pick specific registries.
+///
+/// # Example
+///
+/// ```rust,no_run
+/// use bgpkit_commons::asinfo::AsInfoBuilder;
+/// use bgpkit_commons::irr::IrrSourceConfig;
+///
+/// // Only RIPE + RADB
+/// let config = IrrSourceConfig::sources(&["RIPE", "RADB"]);
+/// let asinfo = AsInfoBuilder::new()
+///     .with_irr_sources(config)
+///     .build()
+///     .unwrap();
+/// ```
+#[derive(Debug, Clone, Default)]
+pub struct IrrSourceConfig {
+    /// Registry names to fetch (e.g. `["RIPE", "RADB"]`).
+    /// If empty, uses all default sources.
+    pub sources: Vec<String>,
+}
+
+impl IrrSourceConfig {
+    /// Create a config that fetches only the named sources.
+    pub fn sources(names: &[&str]) -> Self {
+        Self {
+            sources: names.iter().map(|s| s.to_string()).collect(),
+        }
+    }
+
+    /// Create a config that fetches all default sources.
+    pub fn all_defaults() -> Self {
+        Self {
+            sources: Vec::new(),
+        }
+    }
+
+    /// Resolve to the actual list of `IrrSource` structs to fetch.
+    fn resolve(&self) -> Vec<crate::irr::IrrSource> {
+        if self.sources.is_empty() {
+            crate::irr::default_sources()
+        } else {
+            crate::irr::all_sources()
+                .into_iter()
+                .filter(|s| self.sources.iter().any(|n| n == s.name))
+                .collect()
+        }
+    }
+}
+
+/// Loading profile for AS information data sources.
+///
+/// Controls which data sources are loaded. Each profile is a curated preset;
+/// use [`AsInfoBuilder`] directly for fine-grained control beyond these.
+///
+/// # Profiles
+///
+/// | Profile | Sources | Load time | Output size |
+/// |---------|---------|-----------|-------------|
+/// | [`Minimum`](AsInfoProfile::Minimum) | `asn.txt` only | ~1s | ~37 MB JSONL |
+/// | [`Default`](AsInfoProfile::Default) | asn.txt + as2org + population + hegemony + peeringdb | ~30s | ~50 MB JSONL |
+/// | [`Full`](AsInfoProfile::Full) | everything: + delegated stats + IRR (all sources) + route prefixes | ~75s | ~210 MB JSONL |
+///
+/// # Example
+///
+/// ```rust,no_run
+/// use bgpkit_commons::asinfo::AsInfoProfile;
+/// use bgpkit_commons::BgpkitCommons;
+///
+/// let mut commons = BgpkitCommons::new();
+/// commons.load_asinfo_with_profile(AsInfoProfile::Full).unwrap();
+/// ```
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub enum AsInfoProfile {
+    /// Core `asn.txt` only: AS names + countries. Fast (~1s), minimal data.
+    Minimum,
+
+    /// Production default: asn.txt + as2org + population + hegemony + peeringdb.
+    /// Matches the current asninfo generator output.
+    #[default]
+    Default,
+
+    /// Everything: all of Default + delegated stats + IRR data from all default
+    /// sources (RIPE, APNIC, ARIN, LACNIC, AFRINIC, NTTCOM, RADB) including
+    /// route prefix lists.
+    Full,
+}
+
+impl AsInfoProfile {
+    /// Convert this profile into a builder configuration.
+    pub fn builder(self) -> AsInfoBuilder {
+        match self {
+            AsInfoProfile::Minimum => AsInfoBuilder::new(),
+            AsInfoProfile::Default => AsInfoBuilder::new()
+                .with_as2org()
+                .with_population()
+                .with_hegemony()
+                .with_peeringdb(),
+            AsInfoProfile::Full => AsInfoBuilder::new()
+                .with_as2org()
+                .with_population()
+                .with_hegemony()
+                .with_peeringdb()
+                .with_delegated()
+                .with_irr()
+                .with_irr_route_prefixes(),
+        }
+    }
+}
+
 /// Builder for configuring which data sources to load for AS information.
+///
+/// This is the canonical way to configure AS info loading. All data sources
+/// are opt-in — the core `asn.txt` name/country data always loads; everything
+/// else is gated behind a builder method.
 ///
 /// # Example
 ///
@@ -194,8 +366,22 @@ const RIR_DELEGATED_STATS_URLS: &[&str] = &[
 /// use bgpkit_commons::asinfo::AsInfoBuilder;
 ///
 /// let asinfo = AsInfoBuilder::new()
+///     .with_delegated()
+///     .with_irr()
 ///     .with_as2org()
 ///     .with_peeringdb()
+///     .build()
+///     .unwrap();
+/// ```
+///
+/// Selecting specific IRR sources only:
+///
+/// ```rust,no_run
+/// use bgpkit_commons::asinfo::AsInfoBuilder;
+/// use bgpkit_commons::asinfo::IrrSourceConfig;
+///
+/// let asinfo = AsInfoBuilder::new()
+///     .with_irr_sources(IrrSourceConfig::sources(&["RIPE", "RADB"]))
 ///     .build()
 ///     .unwrap();
 /// ```
@@ -205,6 +391,10 @@ pub struct AsInfoBuilder {
     load_population: bool,
     load_hegemony: bool,
     load_peeringdb: bool,
+    load_delegated: bool,
+    load_irr: bool,
+    irr_config: IrrSourceConfig,
+    irr_route_prefixes: bool,
 }
 
 impl AsInfoBuilder {
@@ -237,45 +427,104 @@ impl AsInfoBuilder {
         self
     }
 
-    /// Enable all optional data sources.
+    /// Enable loading RIR delegated-stats data (registry, country, date, status
+    /// per ASN from five RIR delegated stats files).
+    pub fn with_delegated(mut self) -> Self {
+        self.load_delegated = true;
+        self
+    }
+
+    /// Enable loading IRR data using all default sources (RIPE, APNIC, ARIN,
+    /// LACNIC, AFRINIC, NTTCOM, RADB).
+    pub fn with_irr(mut self) -> Self {
+        self.load_irr = true;
+        self
+    }
+
+    /// Enable loading IRR data with a custom set of sources.
+    ///
+    /// # Example
+    ///
+    /// ```rust,no_run
+    /// use bgpkit_commons::asinfo::{AsInfoBuilder, IrrSourceConfig};
+    ///
+    /// let asinfo = AsInfoBuilder::new()
+    ///     .with_irr_sources(IrrSourceConfig::sources(&["RIPE", "RADB"]))
+    ///     .build()
+    ///     .unwrap();
+    /// ```
+    pub fn with_irr_sources(mut self, config: IrrSourceConfig) -> Self {
+        self.load_irr = true;
+        self.irr_config = config;
+        self
+    }
+
+    /// Enable collecting IRR route/route6 prefix lists per ASN.
+    ///
+    /// Off by default — prefix lists are the largest data component
+    /// (~90MB JSON for all sources). Only enable when you need the
+    /// actual registered prefixes, not just AS names/metadata.
+    pub fn with_irr_route_prefixes(mut self) -> Self {
+        self.irr_route_prefixes = true;
+        self
+    }
+
+    /// Enable all optional data sources with default IRR source set.
     pub fn with_all(mut self) -> Self {
         self.load_as2org = true;
         self.load_population = true;
         self.load_hegemony = true;
         self.load_peeringdb = true;
+        self.load_delegated = true;
+        self.load_irr = true;
         self
     }
 
     /// Build the AsInfoUtils with the configured data sources.
     pub fn build(self) -> Result<AsInfoUtils> {
-        AsInfoUtils::new(
-            self.load_as2org,
-            self.load_population,
-            self.load_hegemony,
-            self.load_peeringdb,
-        )
+        AsInfoUtils::from_builder(&self)
     }
+
+    /// Internal: expose config for AsInfoUtils construction.
+    fn config(&self) -> AsInfoLoadConfig {
+        AsInfoLoadConfig {
+            load_as2org: self.load_as2org,
+            load_population: self.load_population,
+            load_hegemony: self.load_hegemony,
+            load_peeringdb: self.load_peeringdb,
+            load_delegated: self.load_delegated,
+            load_irr: self.load_irr,
+            irr_sources: self.irr_config.resolve(),
+            irr_route_prefixes: self.irr_route_prefixes,
+        }
+    }
+}
+
+/// Internal configuration extracted from the builder.
+#[derive(Debug, Clone)]
+struct AsInfoLoadConfig {
+    load_as2org: bool,
+    load_population: bool,
+    load_hegemony: bool,
+    load_peeringdb: bool,
+    load_delegated: bool,
+    load_irr: bool,
+    irr_sources: Vec<crate::irr::IrrSource>,
+    irr_route_prefixes: bool,
 }
 
 pub struct AsInfoUtils {
     pub asinfo_map: HashMap<u32, AsInfo>,
     pub sibling_orgs: Option<SiblingOrgsUtils>,
-    pub load_as2org: bool,
-    pub load_population: bool,
-    pub load_hegemony: bool,
-    pub load_peeringdb: bool,
+    config: AsInfoLoadConfig,
 }
 
 impl AsInfoUtils {
-    pub fn new(
-        load_as2org: bool,
-        load_population: bool,
-        load_hegemony: bool,
-        load_peeringdb: bool,
-    ) -> Result<Self> {
-        let asinfo_map =
-            get_asinfo_map(load_as2org, load_population, load_hegemony, load_peeringdb)?;
-        let sibling_orgs = if load_as2org {
+    /// Build from a builder (canonical path).
+    fn from_builder(builder: &AsInfoBuilder) -> Result<Self> {
+        let config = builder.config();
+        let asinfo_map = get_asinfo_map(&config)?;
+        let sibling_orgs = if config.load_as2org {
             Some(SiblingOrgsUtils::new()?)
         } else {
             None
@@ -283,10 +532,7 @@ impl AsInfoUtils {
         Ok(AsInfoUtils {
             asinfo_map,
             sibling_orgs,
-            load_as2org,
-            load_population,
-            load_hegemony,
-            load_peeringdb,
+            config,
         })
     }
 
@@ -296,20 +542,21 @@ impl AsInfoUtils {
         Ok(AsInfoUtils {
             asinfo_map,
             sibling_orgs,
-            load_as2org: true,
-            load_population: true,
-            load_hegemony: true,
-            load_peeringdb: true,
+            config: AsInfoLoadConfig {
+                load_as2org: true,
+                load_population: true,
+                load_hegemony: true,
+                load_peeringdb: true,
+                load_delegated: true,
+                load_irr: true,
+                irr_sources: crate::irr::default_sources(),
+                irr_route_prefixes: false,
+            },
         })
     }
 
     pub fn reload(&mut self) -> Result<()> {
-        self.asinfo_map = get_asinfo_map(
-            self.load_as2org,
-            self.load_population,
-            self.load_hegemony,
-            self.load_peeringdb,
-        )?;
+        self.asinfo_map = get_asinfo_map(&self.config)?;
         Ok(())
     }
 
@@ -351,14 +598,14 @@ pub fn get_asinfo_map_cached() -> Result<HashMap<u32, AsInfo>> {
     Ok(asnames_map)
 }
 
-/// Parse RIR delegated stats text (NRO format) into an ASN -> country code map.
+/// Parse RIR delegated stats text (NRO format) into an ASN -> DelegatedInfo map.
 ///
 /// Record format: `registry|CC|type|start|value|date|status[|extensions]`.
 /// Only `asn` records with `allocated`/`assigned` status and a real (non-empty,
 /// non-`*`) country code are kept; private-use ASN ranges (RFC 6996:
 /// 64512-65534 and 4200000000+) are excluded. Ranges are expanded per-ASN
 /// (`value` is a count).
-fn parse_delegated_stats(text: &str, map: &mut HashMap<u32, String>) {
+fn parse_delegated_stats(text: &str, map: &mut HashMap<u32, DelegatedInfo>) {
     for line in text.lines() {
         let line = line.trim();
         if line.is_empty() || line.starts_with('#') {
@@ -379,6 +626,9 @@ fn parse_delegated_stats(text: &str, map: &mut HashMap<u32, String>) {
         let (Ok(start), Ok(count)) = (parts[3].parse::<u64>(), parts[4].parse::<u64>()) else {
             continue;
         };
+        let registry = parts[0].trim().to_lowercase();
+        let country = cc.to_uppercase();
+        let date = parts.get(5).unwrap_or(&"").trim().to_string();
         for asn in start..start.saturating_add(count) {
             if asn > u32::MAX as u64 {
                 break;
@@ -387,7 +637,12 @@ fn parse_delegated_stats(text: &str, map: &mut HashMap<u32, String>) {
             if (64512..=65534).contains(&asn) || asn >= 4_200_000_000 {
                 continue;
             }
-            map.insert(asn, cc.to_uppercase());
+            map.entry(asn).or_insert(DelegatedInfo {
+                registry: registry.clone(),
+                country: country.clone(),
+                date: date.clone(),
+                status: status.to_string(),
+            });
         }
     }
 }
@@ -422,18 +677,16 @@ fn lookup_enrichment(
     (as2org, population, hegemony, peeringdb)
 }
 
-/// Fill ASNs missing from the RIPE NCC `asn.txt`-derived map using the five
-/// RIR delegated stats files (authoritative allocation data, updated daily).
+/// Load RIR delegated stats and attach [`DelegatedInfo`] to every ASN in the
+/// map. For ASNs missing from `asn.txt`, new entries are created with
+/// `name: "UNKNOWN"` and the delegated country code.
 ///
-/// `asn.txt` lags behind new allocations by days to weeks; the delegated
-/// stats cover them. Synthesized entries carry the allocated country code and
-/// an `"UNKNOWN"` name (delegated stats do not include names). Optional
-/// enrichment fields (as2org, population, hegemony, peeringdb) are looked up
-/// from the already-loaded datasets, so `get_preferred_name()` can still
-/// resolve a real name for filled ASNs registered in PeeringDB/as2org.
+/// Delegated stats are authoritative allocation records updated daily, covering
+/// newly-allocated ASNs that `asn.txt` lags on by days to weeks. Every ASN
+/// (not just gap ASNs) gets structured delegated data attached.
 ///
 /// Best-effort: failures fetching individual files are logged and skipped.
-fn fill_missing_asns_from_delegated_stats(
+fn fill_delegated_data(
     asnames_map: &mut HashMap<u32, AsInfo>,
     as2org_utils: Option<&as2org::As2org>,
     population_utils: Option<&population::AsnPopulation>,
@@ -446,7 +699,7 @@ fn fill_missing_asns_from_delegated_stats(
         Ok(text)
     };
 
-    let mut delegated: HashMap<u32, String> = HashMap::new();
+    let mut delegated: HashMap<u32, DelegatedInfo> = HashMap::new();
     for url in RIR_DELEGATED_STATS_URLS {
         match read_text(url) {
             Ok(text) => parse_delegated_stats(&text, &mut delegated),
@@ -454,33 +707,236 @@ fn fill_missing_asns_from_delegated_stats(
         }
     }
 
-    let mut filled = 0usize;
-    for (asn, country) in delegated {
-        asnames_map.entry(asn).or_insert_with(|| {
-            filled += 1;
-            let (as2org, population, hegemony, peeringdb) = lookup_enrichment(
-                asn,
-                as2org_utils,
-                population_utils,
-                hegemony_utils,
-                peeringdb_utils,
-            );
-            AsInfo {
-                asn,
-                name: "UNKNOWN".to_string(),
-                country,
-                as2org,
-                population,
-                hegemony,
-                peeringdb,
-            }
-        });
+    // Attach delegated data to existing entries, and create new entries for
+    // ASNs missing from asn.txt.
+    let mut new_entries = 0usize;
+    let mut attached = 0usize;
+    for (asn, delegated_info) in delegated {
+        asnames_map
+            .entry(asn)
+            .and_modify(|info| {
+                info.delegated = Some(delegated_info.clone());
+                attached += 1;
+            })
+            .or_insert_with(|| {
+                new_entries += 1;
+                let (as2org, population, hegemony, peeringdb) = lookup_enrichment(
+                    asn,
+                    as2org_utils,
+                    population_utils,
+                    hegemony_utils,
+                    peeringdb_utils,
+                );
+                AsInfo {
+                    asn,
+                    name: "UNKNOWN".to_string(),
+                    country: delegated_info.country.clone(),
+                    as2org,
+                    population,
+                    hegemony,
+                    peeringdb,
+                    delegated: Some(delegated_info.clone()),
+                    irr: Vec::new(),
+                }
+            });
     }
     info!(
-        "filled {} ASNs missing from RIPE NCC asn.txt via RIR delegated stats",
-        filled
+        "delegated stats: {attached} existing entries enriched, {new_entries} new entries created"
     );
 }
+/// Enrich ASInfo entries with structured IRR data from all default sources.
+///
+/// For each IRR source (RIPE, APNIC, ARIN, LACNIC, AFRINIC, NTTCOM, RADB),
+/// collects:
+/// - `aut-num` objects → `as-name`, `descr`, `mnt-by`
+/// - `route` objects → registered IPv4 prefixes per ASN
+/// - `route6` objects → registered IPv6 prefixes per ASN
+/// - `as-set` objects → reverse membership (which sets contain this ASN)
+///
+/// Each source produces an [`IrrAsnInfo`] entry in the `irr` Vec, so callers
+/// can pick which source(s) to trust. Per-source failures are logged and
+/// skipped.
+///
+/// Additionally, for entries whose `name` is `"UNKNOWN"`, the `as-name` from
+/// the first IRR source (by default priority order) that has a non-empty name
+/// replaces the placeholder.
+fn enrich_from_irr(
+    asnames_map: &mut HashMap<u32, AsInfo>,
+    irr_sources: &[crate::irr::IrrSource],
+    collect_route_prefixes: bool,
+) {
+    use crate::irr::sources::DumpFormat;
+    use crate::irr::types::{IrrObject, IrrObjectType};
+    use std::collections::HashMap as StdMap;
+
+    // Per-source accumulator: source_name -> (asn -> IrrAsnInfo builder)
+    let mut per_source: StdMap<String, StdMap<u32, IrrAsnInfoBuilder>> = StdMap::new();
+
+    // Track which dump URLs we've already parsed (whole-DB files serve all types).
+    let mut parsed_urls: std::collections::HashSet<String> = std::collections::HashSet::new();
+
+    let wanted_types: Vec<IrrObjectType> = if collect_route_prefixes {
+        vec![
+            IrrObjectType::AutNum,
+            IrrObjectType::Route,
+            IrrObjectType::Route6,
+            IrrObjectType::AsSet,
+        ]
+    } else {
+        // Without route prefixes: only aut-num + as-set.
+        // For WholeDb sources this means we still download once but skip route objects.
+        // For SplitFile sources we skip the route/route6 files entirely.
+        vec![IrrObjectType::AutNum, IrrObjectType::AsSet]
+    };
+
+    for source in irr_sources.iter().cloned() {
+        let source_name = source.name.to_string();
+
+        // For each source, figure out the unique URLs to download.
+        // SplitFile sources have one URL per type; WholeDb has a single URL
+        // that we parse once and extract all types.
+        let mut urls_to_parse: Vec<(String, Vec<IrrObjectType>)> = Vec::new();
+
+        if source.format == DumpFormat::WholeDb {
+            // Single URL, parse once for all types
+            let url = source.dump_urls(IrrObjectType::AutNum);
+            if let Some(dump) = url.first() {
+                urls_to_parse.push((dump.url.clone(), wanted_types.to_vec()));
+            }
+        } else {
+            // Split files: one URL per type
+            for obj_type in &wanted_types {
+                for dump in source.dump_urls(*obj_type) {
+                    urls_to_parse.push((dump.url.clone(), vec![*obj_type]));
+                }
+            }
+        }
+
+        for (url, _types_for_url) in urls_to_parse {
+            if parsed_urls.contains(&url) {
+                continue;
+            }
+            parsed_urls.insert(url.clone());
+
+            let sn = source_name.clone();
+
+            match crate::irr::parse_dump(
+                &crate::irr::IrrDumpUrl {
+                    url: url.clone(),
+                    transport: source.transport,
+                    format: source.format,
+                },
+                |obj| {
+                    let source_map = per_source.entry(sn.clone()).or_default();
+                    match &obj {
+                        IrrObject::AutNum(a) => {
+                            let entry = source_map.entry(a.asn).or_default();
+                            entry.source = a.source.clone();
+                            entry.as_name = a.as_name.clone();
+                            entry.descr = a.descr.clone();
+                            if let Some(mnt) = a.extra.get("mnt-by") {
+                                entry.mnt_by = mnt.clone();
+                            }
+                        }
+                        IrrObject::Route(r) => {
+                            let entry = source_map.entry(r.origin).or_default();
+                            if entry.source.is_empty() {
+                                entry.source = r.source.clone();
+                            }
+                            entry.route_prefixes.push(r.prefix.to_string());
+                        }
+                        IrrObject::Route6(r) => {
+                            let entry = source_map.entry(r.origin).or_default();
+                            if entry.source.is_empty() {
+                                entry.source = r.source.clone();
+                            }
+                            entry.route6_prefixes.push(r.prefix.to_string());
+                        }
+                        IrrObject::AsSet(s) => {
+                            let set_name = s.name.clone();
+                            for &member_asn in &s.members {
+                                let entry = source_map.entry(member_asn).or_default();
+                                if entry.source.is_empty() {
+                                    entry.source = sn.clone();
+                                }
+                                entry.member_of_sets.push(set_name.clone());
+                            }
+                        }
+                        _ => {}
+                    }
+                },
+            ) {
+                Ok(stats) => info!(
+                    "IRR from {source_name} ({url}): {} objects extracted",
+                    stats.extracted
+                ),
+                Err(e) => warn!("failed to load IRR from {source_name} ({url}): {e}"),
+            }
+        }
+    }
+
+    // Attach per-source IrrAsnInfo to each ASN
+    let mut irr_attached = 0usize;
+    let mut names_filled = 0usize;
+
+    for (asn, info) in asnames_map.iter_mut() {
+        let mut irr_entries: Vec<IrrAsnInfo> = Vec::new();
+
+        for source in irr_sources.iter().cloned() {
+            if let Some(source_map) = per_source.get(source.name) {
+                if let Some(builder) = source_map.get(asn) {
+                    irr_entries.push(builder.clone().build());
+                }
+            }
+        }
+
+        // Fill UNKNOWN name from first IRR source with a non-empty as_name
+        if info.name == "UNKNOWN" {
+            for irr_info in &irr_entries {
+                if !irr_info.as_name.is_empty() {
+                    info.name = irr_info.as_name.clone();
+                    names_filled += 1;
+                    break;
+                }
+            }
+        }
+
+        if !irr_entries.is_empty() {
+            info.irr = irr_entries;
+            irr_attached += 1;
+        }
+    }
+
+    info!("IRR data attached to {irr_attached} ASNs, {names_filled} UNKNOWN names filled from IRR");
+}
+
+/// Builder for IrrAsnInfo — accumulates data from multiple object types
+/// (aut-num, route, route6, as-set) before producing the final struct.
+#[derive(Debug, Clone, Default)]
+struct IrrAsnInfoBuilder {
+    as_name: String,
+    descr: Vec<String>,
+    source: String,
+    mnt_by: Vec<String>,
+    route_prefixes: Vec<String>,
+    route6_prefixes: Vec<String>,
+    member_of_sets: Vec<String>,
+}
+
+impl IrrAsnInfoBuilder {
+    fn build(self) -> IrrAsnInfo {
+        IrrAsnInfo {
+            as_name: self.as_name,
+            descr: self.descr,
+            source: self.source,
+            mnt_by: self.mnt_by,
+            route_prefixes: self.route_prefixes,
+            route6_prefixes: self.route6_prefixes,
+            member_of_sets: self.member_of_sets,
+        }
+    }
+}
+
 /// Loads the ASN information map and returns it.
 ///
 /// The core RIPE NCC `asn.txt` data (plus the RIR delegated-stats fill) is
@@ -488,13 +944,18 @@ fn fill_missing_asns_from_delegated_stats(
 /// (as2org, population, hegemony, peeringdb) fail soft — a failed download or
 /// API error (e.g., PeeringDB rate limiting without `PEERINGDB_API_KEY`)
 /// logs a warning and proceeds with that dataset's fields left as `None`.
-pub fn get_asinfo_map(
-    load_as2org: bool,
-    load_population: bool,
-    load_hegemony: bool,
-    load_peeringdb: bool,
-) -> Result<HashMap<u32, AsInfo>> {
-    info!("loading asinfo from RIPE NCC...");
+/// Loads the ASN information map and returns it.
+///
+/// The core RIPE NCC `asn.txt` data (plus the RIR delegated-stats fill) is
+/// required: load failures propagate as `Err`. Optional enrichment datasets
+/// (as2org, population, hegemony, peeringdb) fail soft — a failed download or
+/// API error (e.g., PeeringDB rate limiting without `PEERINGDB_API_KEY`)
+/// logs a warning and proceeds with that dataset's fields left as `None`.
+fn get_asinfo_map(config: &AsInfoLoadConfig) -> Result<HashMap<u32, AsInfo>> {
+    let load_as2org = config.load_as2org;
+    let load_population = config.load_population;
+    let load_hegemony = config.load_hegemony;
+    let load_peeringdb = config.load_peeringdb;
     let read_text = |url: &str| -> Result<String> {
         let mut text = String::new();
         oneio::get_reader(url)?.read_to_string(&mut text)?;
@@ -595,6 +1056,8 @@ pub fn get_asinfo_map(
                 population,
                 hegemony,
                 peeringdb,
+                delegated: None,
+                irr: Vec::new(),
             })
         })
         .collect::<Vec<AsInfo>>();
@@ -604,14 +1067,25 @@ pub fn get_asinfo_map(
         asnames_map.insert(asname.asn, asname);
     }
 
-    info!("filling ASNs missing from RIPE NCC asn.txt via RIR delegated stats...");
-    fill_missing_asns_from_delegated_stats(
-        &mut asnames_map,
-        as2org_utils.as_ref(),
-        population_utils.as_ref(),
-        hegemony_utils.as_ref(),
-        peeringdb_utils.as_ref(),
-    );
+    if config.load_delegated {
+        info!("loading delegated stats data...");
+        fill_delegated_data(
+            &mut asnames_map,
+            as2org_utils.as_ref(),
+            population_utils.as_ref(),
+            hegemony_utils.as_ref(),
+            peeringdb_utils.as_ref(),
+        );
+    }
+
+    if config.load_irr {
+        info!("enriching from IRR data...");
+        enrich_from_irr(
+            &mut asnames_map,
+            &config.irr_sources,
+            config.irr_route_prefixes,
+        );
+    }
 
     Ok(asnames_map)
 }
@@ -630,7 +1104,7 @@ impl BgpkitCommons {
     /// use bgpkit_commons::BgpkitCommons;
     ///
     /// let mut bgpkit = BgpkitCommons::new();
-    /// bgpkit.load_asinfo(false, false, false, false).unwrap();
+    /// bgpkit.load_asinfo_with_profile(Default::default()).unwrap();
     /// let all_asinfo = bgpkit.asinfo_all().unwrap();
     /// ```
     pub fn asinfo_all(&self) -> Result<HashMap<u32, AsInfo>> {
@@ -662,7 +1136,7 @@ impl BgpkitCommons {
     /// use bgpkit_commons::BgpkitCommons;
     ///
     /// let mut bgpkit = BgpkitCommons::new();
-    /// bgpkit.load_asinfo(false, false, false, false).unwrap();
+    /// bgpkit.load_asinfo_with_profile(Default::default()).unwrap();
     /// let asinfo = bgpkit.asinfo_get(3333).unwrap();
     /// ```
     pub fn asinfo_get(&self, asn: u32) -> Result<Option<AsInfo>> {
@@ -694,7 +1168,7 @@ impl BgpkitCommons {
     /// use bgpkit_commons::BgpkitCommons;
     ///
     /// let mut bgpkit = BgpkitCommons::new();
-    /// bgpkit.load_asinfo(true, false, false, false).unwrap();
+    /// bgpkit.load_asinfo_with(bgpkit.asinfo_builder().with_as2org()).unwrap();
     /// let are_siblings = bgpkit.asinfo_are_siblings(3333, 3334).unwrap();
     /// ```
     ///
@@ -708,7 +1182,7 @@ impl BgpkitCommons {
                 load_methods::LOAD_ASINFO,
             ));
         }
-        if !self.asinfo.as_ref().unwrap().load_as2org {
+        if !self.asinfo.as_ref().unwrap().config.load_as2org {
             return Err(BgpkitCommonsError::module_not_configured(
                 modules::ASINFO,
                 "as2org data",
@@ -741,10 +1215,15 @@ impl BgpkitCommons {
 mod tests {
     use super::*;
 
+    /// Helper: check country from DelegatedInfo in map.
+    fn cc(map: &HashMap<u32, DelegatedInfo>, asn: u32) -> Option<&str> {
+        map.get(&asn).map(|d| d.country.as_str())
+    }
+
     #[test]
     fn test_parse_delegated_stats_basic() {
         let text = "\
-2|ripencc|ZZ|209|20250704|00000000+000000+00000000|UTF-8
+2|ripencc|ZZ|209|20250704|00000000+00000000+00000000|UTF-8
 ripencc|*|asn|*|39634|summary
 ripencc|GB|asn|219157|1|20260722|allocated
 ripencc|DE|asn|219125|1|20260728|allocated
@@ -757,18 +1236,23 @@ ripencc|NL|ipv4|185.0.0.0|65536|20000101|allocated
 ";
         let mut map = HashMap::new();
         parse_delegated_stats(text, &mut map);
-        assert_eq!(map.get(&219157).map(String::as_str), Some("GB"));
-        assert_eq!(map.get(&219125).map(String::as_str), Some("DE"));
-        assert_eq!(map.get(&402598).map(String::as_str), Some("US"));
-        assert_eq!(map.get(&154708).map(String::as_str), Some("BD"));
+        assert_eq!(cc(&map, 219157), Some("GB"));
+        assert_eq!(cc(&map, 219125), Some("DE"));
+        assert_eq!(cc(&map, 402598), Some("US"));
+        assert_eq!(cc(&map, 154708), Some("BD"));
         // range expansion: AS1000..=AS1003 (value is a count of 4)
-        assert_eq!(map.get(&1000).map(String::as_str), Some("NL"));
-        assert_eq!(map.get(&1003).map(String::as_str), Some("NL"));
+        assert_eq!(cc(&map, 1000), Some("NL"));
+        assert_eq!(cc(&map, 1003), Some("NL"));
         assert!(!map.contains_key(&1004));
         // reserved entries with empty CC are skipped
         assert!(!map.contains_key(&212));
         // non-asn records are skipped
         assert_eq!(map.len(), 8);
+        // Verify structured fields
+        let info = &map[&219157];
+        assert_eq!(info.registry, "ripencc");
+        assert_eq!(info.status, "allocated");
+        assert_eq!(info.date, "20260722");
     }
 
     #[test]
@@ -798,8 +1282,8 @@ arin|US|asn|300003|1|20200101|assigned
         parse_delegated_stats(text, &mut map);
         assert!(!map.contains_key(&300000));
         assert!(!map.contains_key(&300001));
-        assert_eq!(map.get(&300002).map(String::as_str), Some("US"));
-        assert_eq!(map.get(&300003).map(String::as_str), Some("US"));
+        assert_eq!(cc(&map, 300002), Some("US"));
+        assert_eq!(cc(&map, 300003), Some("US"));
         assert_eq!(map.len(), 2);
     }
 
@@ -817,10 +1301,10 @@ arin|US|asn|4200000000|1|19891201|allocated
 ";
         let mut map = HashMap::new();
         parse_delegated_stats(text, &mut map);
-        assert_eq!(map.get(&65535).map(String::as_str), Some("US"));
+        assert_eq!(cc(&map, 65535), Some("US"));
         assert!(!map.contains_key(&65534));
-        assert_eq!(map.get(&64496).map(String::as_str), Some("US"));
-        assert_eq!(map.get(&4199999999).map(String::as_str), Some("US"));
+        assert_eq!(cc(&map, 64496), Some("US"));
+        assert_eq!(cc(&map, 4199999999), Some("US"));
         assert!(!map.contains_key(&4200000000));
     }
 
@@ -829,7 +1313,8 @@ arin|US|asn|4200000000|1|19891201|allocated
         let text = "lacnic|br|asn|269000|1|20150101|allocated\n";
         let mut map = HashMap::new();
         parse_delegated_stats(text, &mut map);
-        assert_eq!(map.get(&269000).map(String::as_str), Some("BR"));
+        assert_eq!(cc(&map, 269000), Some("BR"));
+        assert_eq!(map[&269000].registry, "lacnic");
     }
 
     #[test]
@@ -848,7 +1333,7 @@ ripencc|GB|asn|100|1|20200101|allocated|extra|fields|ok
         parse_delegated_stats(text, &mut map);
         // empty registry is kept (only CC matters), short lines dropped,
         // extended lines with >7 fields still parsed
-        assert_eq!(map.get(&100).map(String::as_str), Some("GB"));
+        assert_eq!(cc(&map, 100), Some("GB"));
         assert_eq!(map.len(), 1);
     }
 }

--- a/src/asinfo/mod.rs
+++ b/src/asinfo/mod.rs
@@ -14,38 +14,13 @@
 //!
 //! # Data structure
 //!
-//! ```rust,no_run
-//! use serde::{Deserialize, Serialize};
-//! #[derive(Debug, Clone, Serialize, Deserialize)]
-//! pub struct AsInfo {
-//!     pub asn: u32,
-//!     pub name: String,
-//!     pub country: String,
-//!     pub as2org: Option<As2orgInfo>,
-//!     pub population: Option<AsnPopulationData>,
-//!     pub hegemony: Option<HegemonyData>,
-//!     pub irr: Vec<IrrAsnInfo>,
-//!     pub delegated: Option<DelegatedInfo>,
-//! }
-//! #[derive(Debug, Clone, Serialize, Deserialize)]
-//! pub struct As2orgInfo {
-//!     pub name: String,
-//!     pub country: String,
-//!     pub org_id: String,
-//!     pub org_name: String,
-//! }
-//! #[derive(Debug, Clone, Serialize, Deserialize)]
-//! pub struct AsnPopulationData {
-//!     pub user_count: i64,
-//!     pub percent_country: f64,
-//!     pub percent_global: f64,
-//!     pub sample_count: i64,
-//! }
-//! #[derive(Debug, Clone, Serialize, Deserialize)]
-//! pub struct HegemonyData {
-//!     pub asn: u32,
-//!     pub ipv4: f64,
-//!     pub ipv6: f64,
+//! ```rust
+//! use bgpkit_commons::asinfo::AsInfo;
+//!
+//! fn inspect(info: &AsInfo) {
+//!     println!("AS{}: {} ({})", info.asn, info.name, info.country);
+//!     println!("delegated: {:?}", info.delegated);
+//!     println!("IRR registries: {}", info.irr.len());
 //! }
 //! ```
 //!
@@ -68,13 +43,9 @@
 //! Directly call the module:
 //!
 //! ```rust,no_run
-//! use std::collections::HashMap;
-//! use bgpkit_commons::asinfo::{AsInfo, get_asinfo_map};
+//! use bgpkit_commons::asinfo::AsInfoBuilder;
 //!
-//! let asinfo: HashMap<u32, AsInfo> = get_asinfo_map(false, false, false, false).unwrap();
-//! assert_eq!(asinfo.get(&3333).unwrap().name, "RIPE-NCC-AS Reseaux IP Europeens Network Coordination Centre (RIPE NCC)");
-//! assert_eq!(asinfo.get(&400644).unwrap().name, "BGPKIT-LLC");
-//! assert_eq!(asinfo.get(&400644).unwrap().country, "US");
+//! let _asinfo = AsInfoBuilder::new().build().unwrap();
 //! ```
 //!
 //! Retrieve all previously generated and cached AS information:
@@ -120,6 +91,7 @@ mod sibling_orgs;
 use crate::errors::{data_sources, load_methods, modules};
 use crate::peeringdb::{Network, Peeringdb};
 use crate::{BgpkitCommons, BgpkitCommonsError, LazyLoadable, Result};
+use ipnet::{IpNet, Ipv4Net, Ipv6Net};
 use serde::{Deserialize, Serialize};
 use sibling_orgs::SiblingOrgsUtils;
 use std::collections::HashMap;
@@ -168,9 +140,9 @@ pub struct IrrAsnInfo {
     /// The `mnt-by` attribute(s) — maintainers controlling this object.
     pub mnt_by: Vec<String>,
     /// Registered IPv4 prefixes from `route` objects with this ASN as origin.
-    pub route_prefixes: Vec<String>,
+    pub route_prefixes: Vec<Ipv4Net>,
     /// Registered IPv6 prefixes from `route6` objects with this ASN as origin.
-    pub route6_prefixes: Vec<String>,
+    pub route6_prefixes: Vec<Ipv6Net>,
     /// AS-set names that contain this ASN as a direct member.
     pub member_of_sets: Vec<String>,
 }
@@ -180,14 +152,20 @@ pub struct AsInfo {
     pub asn: u32,
     pub name: String,
     pub country: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub as2org: Option<As2orgInfo>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub population: Option<AsnPopulationData>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub hegemony: Option<HegemonyData>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub peeringdb: Option<Network>,
     /// RIR delegated-stats allocation data. Present for every allocated ASN.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub delegated: Option<DelegatedInfo>,
     /// IRR data per registry source. Empty if the ASN has no IRR registrations.
     /// Multiple sources may have data; callers choose which to trust.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub irr: Vec<IrrAsnInfo>,
 }
 
@@ -229,31 +207,19 @@ const RIPE_RIS_ASN_TXT_URL: &str = "https://ftp.ripe.net/ripe/asnames/asn.txt";
 const BGPKIT_ASN_TXT_MIRROR_URL: &str = "https://data.bgpkit.com/commons/asn.txt";
 const BGPKIT_ASNINFO_URL: &str = "https://data.bgpkit.com/commons/asinfo.jsonl";
 
-/// RIR delegated stats files (NRO format), used to fill ASNs missing from
-/// RIPE NCC `asn.txt`. These files are authoritative allocation records,
-/// updated daily, and include newly-allocated ASNs that `asn.txt` lags on
-/// by days to weeks.
-const RIR_DELEGATED_STATS_URLS: &[&str] = &[
-    "https://ftp.arin.net/pub/stats/arin/delegated-arin-extended-latest",
-    "https://ftp.ripe.net/pub/stats/ripencc/delegated-ripencc-latest",
-    "https://ftp.apnic.net/pub/stats/apnic/delegated-apnic-latest",
-    "https://ftp.lacnic.net/pub/stats/lacnic/delegated-lacnic-latest",
-    "https://ftp.afrinic.net/pub/stats/afrinic/delegated-afrinic-latest",
-];
-
 /// Configuration for which IRR sources to fetch.
 ///
-/// By default, `with_irr()` uses the default source set (5 RIRs + NTTCOM + RADB).
+/// By default, `with_irr()` uses every catalogued source.
 /// For finer control, use `with_irr_sources()` to pick specific registries.
 ///
 /// # Example
 ///
 /// ```rust,no_run
 /// use bgpkit_commons::asinfo::AsInfoBuilder;
-/// use bgpkit_commons::irr::IrrSourceConfig;
+/// use bgpkit_commons::asinfo::IrrSourceConfig;
 ///
 /// // Only RIPE + RADB
-/// let config = IrrSourceConfig::sources(&["RIPE", "RADB"]);
+/// let config = IrrSourceConfig::sources(&["RIPE", "RADB"]).unwrap();
 /// let asinfo = AsInfoBuilder::new()
 ///     .with_irr_sources(config)
 ///     .build()
@@ -262,34 +228,36 @@ const RIR_DELEGATED_STATS_URLS: &[&str] = &[
 #[derive(Debug, Clone, Default)]
 pub struct IrrSourceConfig {
     /// Registry names to fetch (e.g. `["RIPE", "RADB"]`).
-    /// If empty, uses all default sources.
+    /// If empty, uses every catalogued source.
     pub sources: Vec<String>,
 }
 
 impl IrrSourceConfig {
     /// Create a config that fetches only the named sources.
-    pub fn sources(names: &[&str]) -> Self {
-        Self {
-            sources: names.iter().map(|s| s.to_string()).collect(),
-        }
+    pub fn sources(names: &[&str]) -> Result<Self> {
+        let selected = crate::irr::sources_by_name(names)?;
+        Ok(Self {
+            sources: selected
+                .into_iter()
+                .map(|source| source.name.to_string())
+                .collect(),
+        })
     }
 
-    /// Create a config that fetches all default sources.
-    pub fn all_defaults() -> Self {
+    /// Create a config that fetches every catalogued source.
+    pub fn all() -> Self {
         Self {
             sources: Vec::new(),
         }
     }
 
     /// Resolve to the actual list of `IrrSource` structs to fetch.
-    fn resolve(&self) -> Vec<crate::irr::IrrSource> {
+    fn resolve(&self) -> Result<Vec<crate::irr::IrrSource>> {
         if self.sources.is_empty() {
-            crate::irr::default_sources()
+            Ok(crate::irr::all_sources())
         } else {
-            crate::irr::all_sources()
-                .into_iter()
-                .filter(|s| self.sources.iter().any(|n| n == s.name))
-                .collect()
+            let names = self.sources.iter().map(String::as_str).collect::<Vec<_>>();
+            crate::irr::sources_by_name(&names)
         }
     }
 }
@@ -326,9 +294,8 @@ pub enum AsInfoProfile {
     #[default]
     Default,
 
-    /// Everything: all of Default + delegated stats + IRR data from all default
-    /// sources (RIPE, APNIC, ARIN, LACNIC, AFRINIC, NTTCOM, RADB) including
-    /// route prefix lists.
+    /// Everything: all of Default + delegated stats + IRR data from every
+    /// catalogued source, including route prefix lists.
     Full,
 }
 
@@ -381,7 +348,7 @@ impl AsInfoProfile {
 /// use bgpkit_commons::asinfo::IrrSourceConfig;
 ///
 /// let asinfo = AsInfoBuilder::new()
-///     .with_irr_sources(IrrSourceConfig::sources(&["RIPE", "RADB"]))
+///     .with_irr_sources(IrrSourceConfig::sources(&["RIPE", "RADB"]).unwrap())
 ///     .build()
 ///     .unwrap();
 /// ```
@@ -434,8 +401,7 @@ impl AsInfoBuilder {
         self
     }
 
-    /// Enable loading IRR data using all default sources (RIPE, APNIC, ARIN,
-    /// LACNIC, AFRINIC, NTTCOM, RADB).
+    /// Enable loading IRR data using every source in the IRR catalog.
     pub fn with_irr(mut self) -> Self {
         self.load_irr = true;
         self
@@ -449,7 +415,7 @@ impl AsInfoBuilder {
     /// use bgpkit_commons::asinfo::{AsInfoBuilder, IrrSourceConfig};
     ///
     /// let asinfo = AsInfoBuilder::new()
-    ///     .with_irr_sources(IrrSourceConfig::sources(&["RIPE", "RADB"]))
+    ///     .with_irr_sources(IrrSourceConfig::sources(&["RIPE", "RADB"]).unwrap())
     ///     .build()
     ///     .unwrap();
     /// ```
@@ -486,17 +452,17 @@ impl AsInfoBuilder {
     }
 
     /// Internal: expose config for AsInfoUtils construction.
-    fn config(&self) -> AsInfoLoadConfig {
-        AsInfoLoadConfig {
+    fn config(&self) -> Result<AsInfoLoadConfig> {
+        Ok(AsInfoLoadConfig {
             load_as2org: self.load_as2org,
             load_population: self.load_population,
             load_hegemony: self.load_hegemony,
             load_peeringdb: self.load_peeringdb,
             load_delegated: self.load_delegated,
             load_irr: self.load_irr,
-            irr_sources: self.irr_config.resolve(),
+            irr_sources: self.irr_config.resolve()?,
             irr_route_prefixes: self.irr_route_prefixes,
-        }
+        })
     }
 }
 
@@ -522,7 +488,7 @@ pub struct AsInfoUtils {
 impl AsInfoUtils {
     /// Build from a builder (canonical path).
     fn from_builder(builder: &AsInfoBuilder) -> Result<Self> {
-        let config = builder.config();
+        let config = builder.config()?;
         let asinfo_map = get_asinfo_map(&config)?;
         let sibling_orgs = if config.load_as2org {
             Some(SiblingOrgsUtils::new()?)
@@ -549,7 +515,7 @@ impl AsInfoUtils {
                 load_peeringdb: true,
                 load_delegated: true,
                 load_irr: true,
-                irr_sources: crate::irr::default_sources(),
+                irr_sources: crate::irr::all_sources(),
                 irr_route_prefixes: false,
             },
         })
@@ -598,52 +564,54 @@ pub fn get_asinfo_map_cached() -> Result<HashMap<u32, AsInfo>> {
     Ok(asnames_map)
 }
 
-/// Parse RIR delegated stats text (NRO format) into an ASN -> DelegatedInfo map.
+/// Project a source-faithful delegated-statistics record into AsInfo data.
 ///
-/// Record format: `registry|CC|type|start|value|date|status[|extensions]`.
 /// Only `asn` records with `allocated`/`assigned` status and a real (non-empty,
 /// non-`*`) country code are kept; private-use ASN ranges (RFC 6996:
 /// 64512-65534 and 4200000000+) are excluded. Ranges are expanded per-ASN
 /// (`value` is a count).
-fn parse_delegated_stats(text: &str, map: &mut HashMap<u32, DelegatedInfo>) {
-    for line in text.lines() {
-        let line = line.trim();
-        if line.is_empty() || line.starts_with('#') {
+fn project_delegated_record(
+    record: crate::delegated::DelegatedRecord,
+    map: &mut HashMap<u32, DelegatedInfo>,
+) {
+    if record.record_type != "asn" {
+        return;
+    }
+    let status = record.status.trim();
+    if status != "allocated" && status != "assigned" {
+        return;
+    }
+    let cc = record.country.trim();
+    if cc.is_empty() || cc == "*" {
+        return;
+    }
+    let (Ok(start), Ok(count)) = (record.start.parse::<u64>(), record.value.parse::<u64>()) else {
+        return;
+    };
+    let registry = record.registry.trim().to_lowercase();
+    let country = cc.to_uppercase();
+    let date = record.date.trim().to_string();
+    for asn in start..start.saturating_add(count) {
+        if asn > u32::MAX as u64 {
+            break;
+        }
+        let asn = asn as u32;
+        if (64512..=65534).contains(&asn) || asn >= 4_200_000_000 {
             continue;
         }
-        let parts: Vec<&str> = line.split('|').collect();
-        if parts.len() < 7 || parts[2] != "asn" {
-            continue;
-        }
-        let status = parts[6].trim();
-        if status != "allocated" && status != "assigned" {
-            continue;
-        }
-        let cc = parts[1].trim();
-        if cc.is_empty() || cc == "*" {
-            continue;
-        }
-        let (Ok(start), Ok(count)) = (parts[3].parse::<u64>(), parts[4].parse::<u64>()) else {
-            continue;
-        };
-        let registry = parts[0].trim().to_lowercase();
-        let country = cc.to_uppercase();
-        let date = parts.get(5).unwrap_or(&"").trim().to_string();
-        for asn in start..start.saturating_add(count) {
-            if asn > u32::MAX as u64 {
-                break;
-            }
-            let asn = asn as u32;
-            if (64512..=65534).contains(&asn) || asn >= 4_200_000_000 {
-                continue;
-            }
-            map.entry(asn).or_insert(DelegatedInfo {
-                registry: registry.clone(),
-                country: country.clone(),
-                date: date.clone(),
-                status: status.to_string(),
-            });
-        }
+        map.entry(asn).or_insert(DelegatedInfo {
+            registry: registry.clone(),
+            country: country.clone(),
+            date: date.clone(),
+            status: status.to_string(),
+        });
+    }
+}
+
+#[cfg(test)]
+fn project_delegated_stats(text: &str, map: &mut HashMap<u32, DelegatedInfo>) {
+    for record in crate::delegated::parse_reader(text.as_bytes()).flatten() {
+        project_delegated_record(record, map);
     }
 }
 
@@ -693,16 +661,17 @@ fn fill_delegated_data(
     hegemony_utils: Option<&hegemony::Hegemony>,
     peeringdb_utils: Option<&Peeringdb>,
 ) {
-    let read_text = |url: &str| -> Result<String> {
-        let mut text = String::new();
-        oneio::get_reader(url)?.read_to_string(&mut text)?;
-        Ok(text)
-    };
-
     let mut delegated: HashMap<u32, DelegatedInfo> = HashMap::new();
-    for url in RIR_DELEGATED_STATS_URLS {
-        match read_text(url) {
-            Ok(text) => parse_delegated_stats(&text, &mut delegated),
+    for url in crate::delegated::RIR_DELEGATED_STATS_URLS {
+        match crate::delegated::fetch(url) {
+            Ok(reader) => {
+                for record in crate::delegated::parse_reader(reader) {
+                    match record {
+                        Ok(record) => project_delegated_record(record, &mut delegated),
+                        Err(e) => warn!("failed to parse delegated stats from {url}: {e}"),
+                    }
+                }
+            }
             Err(e) => warn!("failed to load delegated stats from {}: {}", url, e),
         }
     }
@@ -744,7 +713,7 @@ fn fill_delegated_data(
         "delegated stats: {attached} existing entries enriched, {new_entries} new entries created"
     );
 }
-/// Enrich ASInfo entries with structured IRR data from all default sources.
+/// Enrich AsInfo entries with structured IRR data from selected sources.
 ///
 /// For each IRR source (RIPE, APNIC, ARIN, LACNIC, AFRINIC, NTTCOM, RADB),
 /// collects:
@@ -757,9 +726,6 @@ fn fill_delegated_data(
 /// can pick which source(s) to trust. Per-source failures are logged and
 /// skipped.
 ///
-/// Additionally, for entries whose `name` is `"UNKNOWN"`, the `as-name` from
-/// the first IRR source (by default priority order) that has a non-empty name
-/// replaces the placeholder.
 fn enrich_from_irr(
     asnames_map: &mut HashMap<u32, AsInfo>,
     irr_sources: &[crate::irr::IrrSource],
@@ -843,14 +809,18 @@ fn enrich_from_irr(
                             if entry.source.is_empty() {
                                 entry.source = r.source.clone();
                             }
-                            entry.route_prefixes.push(r.prefix.to_string());
+                            if let IpNet::V4(prefix) = r.prefix {
+                                entry.route_prefixes.push(prefix);
+                            }
                         }
                         IrrObject::Route6(r) => {
                             let entry = source_map.entry(r.origin).or_default();
                             if entry.source.is_empty() {
                                 entry.source = r.source.clone();
                             }
-                            entry.route6_prefixes.push(r.prefix.to_string());
+                            if let IpNet::V6(prefix) = r.prefix {
+                                entry.route6_prefixes.push(prefix);
+                            }
                         }
                         IrrObject::AsSet(s) => {
                             let set_name = s.name.clone();
@@ -877,7 +847,6 @@ fn enrich_from_irr(
 
     // Attach per-source IrrAsnInfo to each ASN
     let mut irr_attached = 0usize;
-    let mut names_filled = 0usize;
 
     for (asn, info) in asnames_map.iter_mut() {
         let mut irr_entries: Vec<IrrAsnInfo> = Vec::new();
@@ -890,24 +859,13 @@ fn enrich_from_irr(
             }
         }
 
-        // Fill UNKNOWN name from first IRR source with a non-empty as_name
-        if info.name == "UNKNOWN" {
-            for irr_info in &irr_entries {
-                if !irr_info.as_name.is_empty() {
-                    info.name = irr_info.as_name.clone();
-                    names_filled += 1;
-                    break;
-                }
-            }
-        }
-
         if !irr_entries.is_empty() {
             info.irr = irr_entries;
             irr_attached += 1;
         }
     }
 
-    info!("IRR data attached to {irr_attached} ASNs, {names_filled} UNKNOWN names filled from IRR");
+    info!("IRR data attached to {irr_attached} ASNs");
 }
 
 /// Builder for IrrAsnInfo — accumulates data from multiple object types
@@ -918,8 +876,8 @@ struct IrrAsnInfoBuilder {
     descr: Vec<String>,
     source: String,
     mnt_by: Vec<String>,
-    route_prefixes: Vec<String>,
-    route6_prefixes: Vec<String>,
+    route_prefixes: Vec<Ipv4Net>,
+    route6_prefixes: Vec<Ipv6Net>,
     member_of_sets: Vec<String>,
 }
 
@@ -1235,7 +1193,7 @@ ripencc|NL|asn|1000|4|19970901|allocated
 ripencc|NL|ipv4|185.0.0.0|65536|20000101|allocated
 ";
         let mut map = HashMap::new();
-        parse_delegated_stats(text, &mut map);
+        project_delegated_stats(text, &mut map);
         assert_eq!(cc(&map, 219157), Some("GB"));
         assert_eq!(cc(&map, 219125), Some("DE"));
         assert_eq!(cc(&map, 402598), Some("US"));
@@ -1264,7 +1222,7 @@ arin|US|asn|notanumber|1|20200101|allocated
 arin|US|asn|123|notacount|20200101|allocated
 ";
         let mut map = HashMap::new();
-        parse_delegated_stats(text, &mut map);
+        project_delegated_stats(text, &mut map);
         assert!(map.is_empty());
     }
 
@@ -1279,7 +1237,7 @@ arin|US|asn|300002|1|20200101|allocated
 arin|US|asn|300003|1|20200101|assigned
 ";
         let mut map = HashMap::new();
-        parse_delegated_stats(text, &mut map);
+        project_delegated_stats(text, &mut map);
         assert!(!map.contains_key(&300000));
         assert!(!map.contains_key(&300001));
         assert_eq!(cc(&map, 300002), Some("US"));
@@ -1300,7 +1258,7 @@ arin|US|asn|4199999999|1|19891201|allocated
 arin|US|asn|4200000000|1|19891201|allocated
 ";
         let mut map = HashMap::new();
-        parse_delegated_stats(text, &mut map);
+        project_delegated_stats(text, &mut map);
         assert_eq!(cc(&map, 65535), Some("US"));
         assert!(!map.contains_key(&65534));
         assert_eq!(cc(&map, 64496), Some("US"));
@@ -1312,7 +1270,7 @@ arin|US|asn|4200000000|1|19891201|allocated
     fn test_parse_delegated_stats_case_normalization() {
         let text = "lacnic|br|asn|269000|1|20150101|allocated\n";
         let mut map = HashMap::new();
-        parse_delegated_stats(text, &mut map);
+        project_delegated_stats(text, &mut map);
         assert_eq!(cc(&map, 269000), Some("BR"));
         assert_eq!(map[&269000].registry, "lacnic");
     }
@@ -1330,10 +1288,54 @@ ripencc|GB|asn|100|1|20200101
 ripencc|GB|asn|100|1|20200101|allocated|extra|fields|ok
 ";
         let mut map = HashMap::new();
-        parse_delegated_stats(text, &mut map);
+        project_delegated_stats(text, &mut map);
         // empty registry is kept (only CC matters), short lines dropped,
         // extended lines with >7 fields still parsed
         assert_eq!(cc(&map, 100), Some("GB"));
         assert_eq!(map.len(), 1);
+    }
+
+    #[test]
+    fn test_profiles_match_asninfo_v1_and_full_uses_all_sources() {
+        let minimum = AsInfoProfile::Minimum.builder().config().unwrap();
+        assert!(!minimum.load_as2org);
+        assert!(!minimum.load_population);
+        assert!(!minimum.load_hegemony);
+        assert!(!minimum.load_peeringdb);
+        assert!(!minimum.load_delegated);
+        assert!(!minimum.load_irr);
+
+        let default = AsInfoProfile::Default.builder().config().unwrap();
+        assert!(default.load_as2org);
+        assert!(default.load_population);
+        assert!(default.load_hegemony);
+        assert!(default.load_peeringdb);
+        assert!(!default.load_delegated);
+        assert!(!default.load_irr);
+
+        let full = AsInfoProfile::Full.builder().config().unwrap();
+        assert!(full.load_delegated);
+        assert!(full.load_irr);
+        assert!(full.irr_route_prefixes);
+        assert_eq!(full.irr_sources.len(), crate::irr::all_sources().len());
+    }
+
+    #[test]
+    fn test_custom_irr_sources_are_validated() {
+        assert!(IrrSourceConfig::sources(&["RIPE", "NOT-A-REGISTRY"]).is_err());
+
+        let selected = IrrSourceConfig::sources(&["RIPE", "RADB"]).unwrap();
+        let config = AsInfoBuilder::new()
+            .with_irr_sources(selected)
+            .config()
+            .unwrap();
+        assert_eq!(
+            config
+                .irr_sources
+                .iter()
+                .map(|source| source.name)
+                .collect::<Vec<_>>(),
+            vec!["RIPE", "RADB"]
+        );
     }
 }

--- a/src/delegated/mod.rs
+++ b/src/delegated/mod.rs
@@ -1,0 +1,79 @@
+//! RIR delegated-statistics source records.
+//!
+//! This module fetches and parses delegated-statistics artifacts without
+//! applying ASInfo enrichment policy.
+
+use std::io::{BufRead, BufReader, Read};
+
+use crate::{BgpkitCommonsError, Result};
+
+/// URLs for the five RIR delegated-statistics artifacts.
+pub const RIR_DELEGATED_STATS_URLS: &[&str] = &[
+    "https://ftp.arin.net/pub/stats/arin/delegated-arin-extended-latest",
+    "https://ftp.ripe.net/pub/stats/ripencc/delegated-ripencc-latest",
+    "https://ftp.apnic.net/pub/stats/apnic/delegated-apnic-latest",
+    "https://ftp.lacnic.net/pub/stats/lacnic/delegated-lacnic-latest",
+    "https://ftp.afrinic.net/pub/stats/afrinic/delegated-afrinic-latest",
+];
+
+/// One source record from an RIR delegated-statistics artifact.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DelegatedRecord {
+    pub registry: String,
+    pub country: String,
+    pub record_type: String,
+    pub start: String,
+    pub value: String,
+    pub date: String,
+    pub status: String,
+    pub extensions: Vec<String>,
+}
+
+/// Parse delegated-statistics records from a caller-provided reader.
+///
+/// Empty lines and comments are ignored. All well-formed source records are
+/// returned without filtering by record type, status, country, or ASN range.
+pub fn parse_reader<R: Read>(reader: R) -> impl Iterator<Item = Result<DelegatedRecord>> {
+    BufReader::new(reader)
+        .lines()
+        .filter_map(|line| match line {
+            Err(error) => Some(Err(error.into())),
+            Ok(line) => {
+                let line = line.trim();
+                if line.is_empty() || line.starts_with('#') {
+                    return None;
+                }
+                Some(parse_line(line))
+            }
+        })
+}
+
+fn parse_line(line: &str) -> Result<DelegatedRecord> {
+    let fields = line.split('|').collect::<Vec<_>>();
+    if fields.len() < 7 {
+        return Err(BgpkitCommonsError::invalid_format(
+            "delegated statistics record",
+            line,
+            "expected at least 7 pipe-delimited fields",
+        ));
+    }
+
+    Ok(DelegatedRecord {
+        registry: fields[0].to_string(),
+        country: fields[1].to_string(),
+        record_type: fields[2].to_string(),
+        start: fields[3].to_string(),
+        value: fields[4].to_string(),
+        date: fields[5].to_string(),
+        status: fields[6].to_string(),
+        extensions: fields[7..]
+            .iter()
+            .map(|value| (*value).to_string())
+            .collect(),
+    })
+}
+
+/// Open a delegated-statistics artifact for streaming parsing.
+pub fn fetch(url: &str) -> Result<Box<dyn Read>> {
+    Ok(oneio::get_reader(url)?)
+}

--- a/src/irr/extract.rs
+++ b/src/irr/extract.rs
@@ -1,0 +1,268 @@
+//! Extract typed [`IrrObject`]s from parsed RPSL objects.
+//!
+//! Each function reads the relevant attributes from a `rpsl::Object<Raw>` and
+//! produces an owned typed struct. Unknown or non-target object types are
+//! skipped by the caller (see [`crate::irr::stream`]).
+
+use std::collections::BTreeMap;
+
+use ipnet::IpNet;
+use rpsl::{Object, spec::Raw};
+
+use crate::BgpkitCommonsError;
+use crate::irr::types::{
+    AsSet, AutNum, IrrObject, IrrObjectType, Mntner, Organisation, Route, RouteSet,
+};
+
+type RpslObj<'a> = Object<'a, Raw>;
+
+/// Collect all values for an attribute name from an RPSL object.
+fn collect_values(obj: &RpslObj<'_>, name: &str) -> Vec<String> {
+    obj.get(name).into_iter().map(String::from).collect()
+}
+
+/// Collect all values and flatten comma-separated entries.
+/// Used for `members:` attributes which may contain `AS1, AS2, AS3`.
+fn collect_values_flat(obj: &RpslObj<'_>, name: &str) -> Vec<String> {
+    let mut result = Vec::new();
+    for value in obj.get(name) {
+        for part in value.split(',') {
+            let trimmed = part.trim();
+            if !trimmed.is_empty() {
+                result.push(trimmed.to_string());
+            }
+        }
+    }
+    result
+}
+
+/// Collect all remaining attributes into a BTreeMap (excluding the ones
+/// we already extracted into named fields).
+fn collect_extra(obj: &RpslObj<'_>, skip: &[&str]) -> BTreeMap<String, Vec<String>> {
+    let mut map = BTreeMap::new();
+    for attr in obj.iter() {
+        let name = attr.name.as_ref();
+        if skip.contains(&name) {
+            continue;
+        }
+        let entry: &mut Vec<String> = map.entry(name.to_string()).or_default();
+        for v in attr.value.with_content() {
+            entry.push(v.to_string());
+        }
+    }
+    map
+}
+
+/// Parse an ASN from an RPSL value string like `"AS13335"`, `"as13335"`, or `"13335"`.
+/// Handles case-insensitive `AS` prefix and strips inline comments (e.g. `AS24665 # SUTC-AS`).
+fn parse_asn(s: &str) -> Result<u32, BgpkitCommonsError> {
+    let s = s.trim();
+    // Strip inline comments (common in RADB route objects)
+    let s = s.split('#').next().unwrap_or(s).trim();
+    let digits = if s.len() >= 2 && s[..2].eq_ignore_ascii_case("AS") {
+        &s[2..]
+    } else {
+        s
+    };
+    digits
+        .parse::<u32>()
+        .map_err(|_| BgpkitCommonsError::invalid_format("ASN", s, "not a valid AS number"))
+}
+
+/// Attempt to extract a typed IRR object from a parsed RPSL object.
+///
+/// Returns `Ok(Some(...))` for supported object types with parseable data,
+/// `Ok(None)` for unsupported or empty object types, and `Err` if a supported
+/// object has malformed critical fields.
+pub fn extract(obj: &RpslObj<'_>) -> Result<Option<IrrObject>, BgpkitCommonsError> {
+    let first = match obj.iter().next() {
+        Some(attr) => attr.name.as_ref(),
+        None => return Ok(None),
+    };
+
+    let obj_type = match IrrObjectType::from_first_attr(first) {
+        Some(t) => t,
+        None => return Ok(None),
+    };
+
+    let result = match obj_type {
+        IrrObjectType::AutNum => {
+            let asn_str = obj.get("aut-num").into_iter().next().ok_or_else(|| {
+                BgpkitCommonsError::invalid_format("aut-num", "(empty)", "missing aut-num value")
+            })?;
+            IrrObject::AutNum(AutNum {
+                asn: parse_asn(asn_str)?,
+                as_name: collect_values(obj, "as-name")
+                    .into_iter()
+                    .next()
+                    .unwrap_or_default(),
+                descr: collect_values(obj, "descr"),
+                source: collect_values(obj, "source")
+                    .into_iter()
+                    .next()
+                    .unwrap_or_default(),
+                extra: collect_extra(obj, &["aut-num", "as-name", "descr", "source"]),
+            })
+        }
+        IrrObjectType::Route => {
+            let prefix_str = obj.get("route").into_iter().next().ok_or_else(|| {
+                BgpkitCommonsError::invalid_format("route", "(empty)", "missing route value")
+            })?;
+            let prefix: IpNet = prefix_str.trim().parse().map_err(|_| {
+                BgpkitCommonsError::invalid_format("route", prefix_str, "not a valid IP prefix")
+            })?;
+            let origin_str = obj.get("origin").into_iter().next().ok_or_else(|| {
+                BgpkitCommonsError::invalid_format("route", "(empty)", "missing origin value")
+            })?;
+            IrrObject::Route(Route {
+                prefix,
+                origin: parse_asn(origin_str)?,
+                descr: collect_values(obj, "descr"),
+                source: collect_values(obj, "source")
+                    .into_iter()
+                    .next()
+                    .unwrap_or_default(),
+                extra: collect_extra(obj, &["route", "origin", "descr", "source"]),
+            })
+        }
+        IrrObjectType::Route6 => {
+            let prefix_str = obj.get("route6").into_iter().next().ok_or_else(|| {
+                BgpkitCommonsError::invalid_format("route6", "(empty)", "missing route6 value")
+            })?;
+            let prefix: IpNet = prefix_str.trim().parse().map_err(|_| {
+                BgpkitCommonsError::invalid_format("route6", prefix_str, "not a valid IPv6 prefix")
+            })?;
+            let origin_str = obj.get("origin").into_iter().next().ok_or_else(|| {
+                BgpkitCommonsError::invalid_format("route6", "(empty)", "missing origin value")
+            })?;
+            IrrObject::Route6(Route {
+                prefix,
+                origin: parse_asn(origin_str)?,
+                descr: collect_values(obj, "descr"),
+                source: collect_values(obj, "source")
+                    .into_iter()
+                    .next()
+                    .unwrap_or_default(),
+                extra: collect_extra(obj, &["route6", "origin", "descr", "source"]),
+            })
+        }
+        IrrObjectType::AsSet => {
+            let name = obj.get("as-set").into_iter().next().ok_or_else(|| {
+                BgpkitCommonsError::invalid_format("as-set", "(empty)", "missing as-set value")
+            })?;
+            let mut members = Vec::new();
+            let mut set_members = Vec::new();
+            for m in collect_values_flat(obj, "members") {
+                if m.starts_with("AS-") || m.starts_with("as-") || m.contains('-') {
+                    set_members.push(m);
+                } else {
+                    match parse_asn(&m) {
+                        Ok(asn) => members.push(asn),
+                        Err(_) => set_members.push(m),
+                    }
+                }
+            }
+            IrrObject::AsSet(AsSet {
+                name: name.to_string(),
+                members,
+                set_members,
+                descr: collect_values(obj, "descr"),
+                source: collect_values(obj, "source")
+                    .into_iter()
+                    .next()
+                    .unwrap_or_default(),
+                extra: collect_extra(obj, &["as-set", "members", "descr", "source"]),
+            })
+        }
+        IrrObjectType::RouteSet => {
+            let name = obj.get("route-set").into_iter().next().ok_or_else(|| {
+                BgpkitCommonsError::invalid_format(
+                    "route-set",
+                    "(empty)",
+                    "missing route-set value",
+                )
+            })?;
+            let mut members = Vec::new();
+            let mut set_members = Vec::new();
+            for m in collect_values_flat(obj, "members") {
+                if let Ok(prefix) = m.parse::<IpNet>() {
+                    members.push(prefix);
+                } else {
+                    set_members.push(m);
+                }
+            }
+            IrrObject::RouteSet(RouteSet {
+                name: name.to_string(),
+                members,
+                set_members,
+                descr: collect_values(obj, "descr"),
+                source: collect_values(obj, "source")
+                    .into_iter()
+                    .next()
+                    .unwrap_or_default(),
+                extra: collect_extra(obj, &["route-set", "members", "descr", "source"]),
+            })
+        }
+        IrrObjectType::Mntner => {
+            let name = obj.get("mntner").into_iter().next().ok_or_else(|| {
+                BgpkitCommonsError::invalid_format("mntner", "(empty)", "missing mntner value")
+            })?;
+            IrrObject::Mntner(Mntner {
+                name: name.to_string(),
+                auth: collect_values(obj, "auth"),
+                upd_to: collect_values(obj, "upd-to"),
+                mnt_nfy: collect_values(obj, "mnt-nfy"),
+                source: collect_values(obj, "source")
+                    .into_iter()
+                    .next()
+                    .unwrap_or_default(),
+                extra: collect_extra(obj, &["mntner", "auth", "upd-to", "mnt-nfy", "source"]),
+            })
+        }
+        IrrObjectType::Organisation => {
+            let id_key = if first == "org" {
+                "org"
+            } else {
+                "organisation"
+            };
+            let id = obj.get(id_key).into_iter().next().ok_or_else(|| {
+                BgpkitCommonsError::invalid_format(
+                    "organisation",
+                    "(empty)",
+                    "missing organisation value",
+                )
+            })?;
+            let name = {
+                let v = collect_values(obj, "org-name");
+                if v.is_empty() {
+                    collect_values(obj, "name")
+                } else {
+                    v
+                }
+            }
+            .into_iter()
+            .next()
+            .unwrap_or_default();
+            IrrObject::Organisation(Organisation {
+                id: id.to_string(),
+                name,
+                org_type: collect_values(obj, "org-type").into_iter().next(),
+                address: collect_values(obj, "address"),
+                country: collect_values(obj, "country").into_iter().next(),
+                abuse_c: collect_values(obj, "abuse-c").into_iter().next(),
+                source: collect_values(obj, "source")
+                    .into_iter()
+                    .next()
+                    .unwrap_or_default(),
+                extra: collect_extra(
+                    obj,
+                    &[
+                        id_key, "org-name", "org-type", "address", "country", "abuse-c", "source",
+                    ],
+                ),
+            })
+        }
+    };
+
+    Ok(Some(result))
+}

--- a/src/irr/mod.rs
+++ b/src/irr/mod.rs
@@ -60,6 +60,10 @@ pub mod types;
 
 pub use sources::{
     DumpFormat, IrrDumpUrl, IrrSource, Transport, all_sources, default_sources, source_by_name,
+    sources_by_name,
 };
-pub use stream::{ParseStats, parse_dump, parse_dump_from_reader};
-pub use types::{AsSet, AutNum, IrrObject, IrrObjectType, Mntner, Organisation, Route, RouteSet};
+pub use stream::{ParseStats, fetch, parse_dump, parse_dump_from_reader, parse_reader};
+pub use types::{
+    AsSet, AutNum, IrrAttribute, IrrObject, IrrObjectType, IrrRecord, Mntner, Organisation, Route,
+    RouteSet,
+};

--- a/src/irr/mod.rs
+++ b/src/irr/mod.rs
@@ -13,9 +13,9 @@
 //!   [`sources::default_sources`] for a curated default set.
 //! - [`types`] — typed Rust structs for the supported RPSL object types
 //!   ([`AutNum`], [`Route`], [`AsSet`], [`RouteSet`], [`Mntner`], [`Organisation`]).
-//! - [`stream`] — a streaming parser that reads gzipped RPSL dump files via
-//!   oneio, splits text into per-object chunks, and extracts typed objects
-//!   using the [`rpsl-rs`](https://crates.io/crates/rpsl-rs) parser.
+//! - [`stream`] — validated dump fetching plus source-faithful streaming
+//!   parsing, with compatibility conversion to typed objects through
+//!   [`rpsl-rs`](https://crates.io/crates/rpsl-rs).
 //!
 //! Downstream applications (e.g. `asninfo`) use these building blocks to build
 //! indexes, resolve as-sets, or merge data across registries.
@@ -34,22 +34,14 @@
 //! # Example
 //!
 //! ```rust,no_run
-//! use bgpkit_commons::irr;
-//! use bgpkit_commons::irr::sources::default_sources;
-//! use bgpkit_commons::irr::types::IrrObjectType;
+//! use bgpkit_commons::irr::{IrrObjectType, fetch, parse_reader, source_by_name};
 //!
-//! // Parse aut-num objects from all default sources
-//! for source in default_sources() {
-//!     for dump_url in source.dump_urls(IrrObjectType::AutNum) {
-//!         println!("Loading {} from {} ({})",
-//!             source.name, dump_url.url, dump_url.transport);
-//!
-//!         irr::stream::parse_dump(&dump_url, |obj| {
-//!             if let irr::types::IrrObject::AutNum(a) = obj {
-//!                 println!("AS{}: {} ({})", a.asn, a.as_name, a.source);
-//!             }
-//!         }).unwrap();
-//!     }
+//! let source = source_by_name("RIPE").unwrap();
+//! let reader = fetch(&source, IrrObjectType::AutNum).unwrap();
+//! let format = reader.dump_url.format;
+//! for record in parse_reader(reader, format) {
+//!     let record = record.unwrap();
+//!     println!("{} with {} attributes", record.object_type, record.attributes.len());
 //! }
 //! ```
 
@@ -62,7 +54,7 @@ pub use sources::{
     DumpFormat, IrrDumpUrl, IrrSource, Transport, all_sources, default_sources, source_by_name,
     sources_by_name,
 };
-pub use stream::{ParseStats, fetch, parse_dump, parse_dump_from_reader, parse_reader};
+pub use stream::{IrrReader, ParseStats, fetch, parse_dump, parse_dump_from_reader, parse_reader};
 pub use types::{
     AsSet, AutNum, IrrAttribute, IrrObject, IrrObjectType, IrrRecord, Mntner, Organisation, Route,
     RouteSet,

--- a/src/irr/mod.rs
+++ b/src/irr/mod.rs
@@ -1,0 +1,65 @@
+//! IRR (Internet Routing Registry) data support.
+//!
+//! This module provides tools for loading and parsing IRR data in RPSL format
+//! from bulk database dumps published by IRR registries worldwide.
+//!
+//! # Design
+//!
+//! The module is a **library-level toolkit**, not an application. It provides:
+//!
+//! - [`sources`] — a registry of known IRR databases with their dump URLs,
+//!   transports (HTTPS/FTP), and publication formats (split files vs whole-DB).
+//!   Use [`sources::all_sources`] to discover everything, or
+//!   [`sources::default_sources`] for a curated default set.
+//! - [`types`] — typed Rust structs for the supported RPSL object types
+//!   ([`AutNum`], [`Route`], [`AsSet`], [`RouteSet`], [`Mntner`], [`Organisation`]).
+//! - [`stream`] — a streaming parser that reads gzipped RPSL dump files via
+//!   oneio, splits text into per-object chunks, and extracts typed objects
+//!   using the [`rpsl-rs`](https://crates.io/crates/rpsl-rs) parser.
+//!
+//! Downstream applications (e.g. `asninfo`) use these building blocks to build
+//! indexes, resolve as-sets, or merge data across registries.
+//!
+//! # Supported Object Types
+//!
+//! | RPSL type | Struct | Key fields |
+//! |-----------|--------|------------|
+//! | `aut-num` | [`AutNum`] | ASN, as-name, descr, source |
+//! | `route` / `route6` | [`Route`] | prefix, origin ASN, source |
+//! | `as-set` | [`AsSet`] | name, AS members, set members (recursive) |
+//! | `route-set` | [`RouteSet`] | name, prefix members, set members (recursive) |
+//! | `mntner` | [`Mntner`] | name, auth methods, notification emails |
+//! | `organisation` | [`Organisation`] | ID, name, address, country, abuse contact |
+//!
+//! # Example
+//!
+//! ```rust,no_run
+//! use bgpkit_commons::irr;
+//! use bgpkit_commons::irr::sources::default_sources;
+//! use bgpkit_commons::irr::types::IrrObjectType;
+//!
+//! // Parse aut-num objects from all default sources
+//! for source in default_sources() {
+//!     for dump_url in source.dump_urls(IrrObjectType::AutNum) {
+//!         println!("Loading {} from {} ({})",
+//!             source.name, dump_url.url, dump_url.transport);
+//!
+//!         irr::stream::parse_dump(&dump_url, |obj| {
+//!             if let irr::types::IrrObject::AutNum(a) = obj {
+//!                 println!("AS{}: {} ({})", a.asn, a.as_name, a.source);
+//!             }
+//!         }).unwrap();
+//!     }
+//! }
+//! ```
+
+pub mod extract;
+pub mod sources;
+pub mod stream;
+pub mod types;
+
+pub use sources::{
+    DumpFormat, IrrDumpUrl, IrrSource, Transport, all_sources, default_sources, source_by_name,
+};
+pub use stream::{ParseStats, parse_dump, parse_dump_from_reader};
+pub use types::{AsSet, AutNum, IrrObject, IrrObjectType, Mntner, Organisation, Route, RouteSet};

--- a/src/irr/sources.rs
+++ b/src/irr/sources.rs
@@ -1,0 +1,325 @@
+//! IRR source registry.
+//!
+//! Defines the known IRR registries, their bulk dump URLs, and which transport
+//! (HTTPS/FTP) and format (split files vs whole-DB) each one uses.
+
+use crate::irr::IrrObjectType;
+
+/// The transport used to fetch a dump file.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Transport {
+    Https,
+    Ftp,
+}
+
+impl std::fmt::Display for Transport {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Transport::Https => write!(f, "HTTPS"),
+            Transport::Ftp => write!(f, "FTP"),
+        }
+    }
+}
+
+/// How a registry publishes its data.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DumpFormat {
+    /// Per-object-type split files (e.g. `ripe.db.aut-num.gz`).
+    /// Only RIPE and APNIC offer this.
+    SplitFiles,
+    /// Single whole-DB file containing all object types (e.g. `arin.db.gz`).
+    WholeDb,
+}
+
+/// A single dump-file URL for a specific object type from a registry.
+#[derive(Debug, Clone)]
+pub struct IrrDumpUrl {
+    /// The full URL to download.
+    pub url: String,
+    /// Transport protocol.
+    pub transport: Transport,
+    /// Whether this is a split file or whole-DB.
+    pub format: DumpFormat,
+}
+
+/// An IRR registry source.
+///
+/// Each entry describes where to fetch bulk RPSL dump files for a registry,
+/// what transport and format are used, and which object types are available.
+#[derive(Debug, Clone)]
+pub struct IrrSource {
+    /// Short registry name (e.g. `"RIPE"`, `"RADB"`).
+    pub name: &'static str,
+    /// Full registry display name.
+    pub display_name: &'static str,
+    /// Whether the registry is an authoritative RIR database (vs third-party).
+    pub authoritative: bool,
+    /// Transport for the primary dump URLs.
+    pub transport: Transport,
+    /// Dump format.
+    pub format: DumpFormat,
+}
+
+impl IrrSource {
+    /// Returns the download URL(s) for a given object type from this registry.
+    ///
+    /// For `SplitFiles` registries (RIPE, APNIC), this returns a single URL
+    /// targeting the requested type. For `WholeDb` registries, this returns
+    /// a single URL for the whole database — the caller must filter by type
+    /// during parsing.
+    pub fn dump_urls(&self, object_type: IrrObjectType) -> Vec<IrrDumpUrl> {
+        match (self.format, self.name) {
+            (DumpFormat::SplitFiles, "RIPE") => {
+                let filename = match object_type {
+                    IrrObjectType::AutNum => "ripe.db.aut-num.gz",
+                    IrrObjectType::Route => "ripe.db.route.gz",
+                    IrrObjectType::Route6 => "ripe.db.route6.gz",
+                    IrrObjectType::AsSet => "ripe.db.as-set.gz",
+                    IrrObjectType::RouteSet => "ripe.db.route-set.gz",
+                    IrrObjectType::Mntner => "ripe.db.mntner.gz",
+                    IrrObjectType::Organisation => "ripe.db.organisation.gz",
+                };
+                vec![IrrDumpUrl {
+                    url: format!("https://ftp.ripe.net/ripe/dbase/split/{filename}"),
+                    transport: Transport::Https,
+                    format: DumpFormat::SplitFiles,
+                }]
+            }
+            (DumpFormat::SplitFiles, "APNIC") => {
+                let filename = match object_type {
+                    IrrObjectType::AutNum => "apnic.db.aut-num.gz",
+                    IrrObjectType::Route => "apnic.db.route.gz",
+                    IrrObjectType::Route6 => "apnic.db.route6.gz",
+                    IrrObjectType::AsSet => "apnic.db.as-set.gz",
+                    IrrObjectType::RouteSet => "apnic.db.route-set.gz",
+                    IrrObjectType::Mntner => "apnic.db.mntner.gz",
+                    IrrObjectType::Organisation => "apnic.db.organisation.gz",
+                };
+                vec![IrrDumpUrl {
+                    url: format!("https://ftp.apnic.net/apnic/whois/{filename}"),
+                    transport: Transport::Https,
+                    format: DumpFormat::SplitFiles,
+                }]
+            }
+            (DumpFormat::WholeDb, "ARIN") => {
+                whole_db("https://ftp.arin.net/pub/rr/arin.db.gz", Transport::Https)
+            }
+            (DumpFormat::WholeDb, "LACNIC") => {
+                whole_db("https://irr.lacnic.net/lacnic.db.gz", Transport::Https)
+            }
+            (DumpFormat::WholeDb, "AFRINIC") => whole_db(
+                "https://ftp.afrinic.net/pub/dbase/afrinic.db.gz",
+                Transport::Https,
+            ),
+            (DumpFormat::WholeDb, "NTTCOM") => whole_db(
+                "https://rr1.ntt.net/nttcomRR/nttcom.db.gz",
+                Transport::Https,
+            ),
+            (DumpFormat::WholeDb, "RADB") => {
+                whole_db("ftp://ftp.radb.net/radb/dbase/radb.db.gz", Transport::Ftp)
+            }
+            (DumpFormat::WholeDb, "ALTDB") => {
+                whole_db("ftp://ftp.radb.net/radb/dbase/altdb.db.gz", Transport::Ftp)
+            }
+            (DumpFormat::WholeDb, "BELL") => {
+                whole_db("ftp://ftp.radb.net/radb/dbase/bell.db.gz", Transport::Ftp)
+            }
+            (DumpFormat::WholeDb, "BBOI") => {
+                whole_db("ftp://ftp.radb.net/radb/dbase/bboi.db.gz", Transport::Ftp)
+            }
+            (DumpFormat::WholeDb, "JPIRR") => {
+                whole_db("ftp://ftp.radb.net/radb/dbase/jpirr.db.gz", Transport::Ftp)
+            }
+            (DumpFormat::WholeDb, "TC") => {
+                whole_db("ftp://ftp.radb.net/radb/dbase/tc.db.gz", Transport::Ftp)
+            }
+            (DumpFormat::WholeDb, "CANARIE") => whole_db(
+                "https://whois.canarie.ca/dbase/canarie.db.gz",
+                Transport::Https,
+            ),
+            (DumpFormat::WholeDb, "REACH") => {
+                whole_db("ftp://ftp.radb.net/radb/dbase/reach.db.gz", Transport::Ftp)
+            }
+            _ => vec![],
+        }
+    }
+}
+
+fn whole_db(url: &str, transport: Transport) -> Vec<IrrDumpUrl> {
+    vec![IrrDumpUrl {
+        url: url.to_string(),
+        transport,
+        format: DumpFormat::WholeDb,
+    }]
+}
+
+/// Returns the list of all known IRR sources.
+pub fn all_sources() -> Vec<IrrSource> {
+    SOURCES.to_vec()
+}
+
+/// Returns the default set of IRR sources.
+///
+/// These are the authoritative RIR databases plus the most commonly used
+/// third-party IRRs. All use HTTPS except RADB which is FTP-only.
+pub fn default_sources() -> Vec<IrrSource> {
+    DEFAULT_SOURCES.to_vec()
+}
+
+/// Look up a source by name (case-sensitive, as used in the RPSL `source:` attribute).
+pub fn source_by_name(name: &str) -> Option<IrrSource> {
+    SOURCES.iter().find(|s| s.name == name).cloned()
+}
+
+const DEFAULT_SOURCES: &[IrrSource] = &[
+    IrrSource {
+        name: "RIPE",
+        display_name: "RIPE NCC",
+        authoritative: true,
+        transport: Transport::Https,
+        format: DumpFormat::SplitFiles,
+    },
+    IrrSource {
+        name: "APNIC",
+        display_name: "APNIC",
+        authoritative: true,
+        transport: Transport::Https,
+        format: DumpFormat::SplitFiles,
+    },
+    IrrSource {
+        name: "ARIN",
+        display_name: "ARIN (IRR)",
+        authoritative: false,
+        transport: Transport::Https,
+        format: DumpFormat::WholeDb,
+    },
+    IrrSource {
+        name: "LACNIC",
+        display_name: "LACNIC",
+        authoritative: true,
+        transport: Transport::Https,
+        format: DumpFormat::WholeDb,
+    },
+    IrrSource {
+        name: "AFRINIC",
+        display_name: "AFRINIC",
+        authoritative: true,
+        transport: Transport::Https,
+        format: DumpFormat::WholeDb,
+    },
+    IrrSource {
+        name: "NTTCOM",
+        display_name: "NTT Communications",
+        authoritative: false,
+        transport: Transport::Https,
+        format: DumpFormat::WholeDb,
+    },
+    IrrSource {
+        name: "RADB",
+        display_name: "RADB (MERIT)",
+        authoritative: false,
+        transport: Transport::Ftp,
+        format: DumpFormat::WholeDb,
+    },
+];
+
+const SOURCES: &[IrrSource] = &[
+    IrrSource {
+        name: "RIPE",
+        display_name: "RIPE NCC",
+        authoritative: true,
+        transport: Transport::Https,
+        format: DumpFormat::SplitFiles,
+    },
+    IrrSource {
+        name: "APNIC",
+        display_name: "APNIC",
+        authoritative: true,
+        transport: Transport::Https,
+        format: DumpFormat::SplitFiles,
+    },
+    IrrSource {
+        name: "ARIN",
+        display_name: "ARIN (IRR)",
+        authoritative: false,
+        transport: Transport::Https,
+        format: DumpFormat::WholeDb,
+    },
+    IrrSource {
+        name: "LACNIC",
+        display_name: "LACNIC",
+        authoritative: true,
+        transport: Transport::Https,
+        format: DumpFormat::WholeDb,
+    },
+    IrrSource {
+        name: "AFRINIC",
+        display_name: "AFRINIC",
+        authoritative: true,
+        transport: Transport::Https,
+        format: DumpFormat::WholeDb,
+    },
+    IrrSource {
+        name: "NTTCOM",
+        display_name: "NTT Communications",
+        authoritative: false,
+        transport: Transport::Https,
+        format: DumpFormat::WholeDb,
+    },
+    IrrSource {
+        name: "RADB",
+        display_name: "RADB (MERIT)",
+        authoritative: false,
+        transport: Transport::Ftp,
+        format: DumpFormat::WholeDb,
+    },
+    IrrSource {
+        name: "ALTDB",
+        display_name: "ALTDB",
+        authoritative: false,
+        transport: Transport::Ftp,
+        format: DumpFormat::WholeDb,
+    },
+    IrrSource {
+        name: "BELL",
+        display_name: "Bell Canada",
+        authoritative: false,
+        transport: Transport::Ftp,
+        format: DumpFormat::WholeDb,
+    },
+    IrrSource {
+        name: "BBOI",
+        display_name: "BBOI",
+        authoritative: false,
+        transport: Transport::Ftp,
+        format: DumpFormat::WholeDb,
+    },
+    IrrSource {
+        name: "JPIRR",
+        display_name: "JPIRR",
+        authoritative: false,
+        transport: Transport::Ftp,
+        format: DumpFormat::WholeDb,
+    },
+    IrrSource {
+        name: "TC",
+        display_name: "TC (Brasil)",
+        authoritative: false,
+        transport: Transport::Ftp,
+        format: DumpFormat::WholeDb,
+    },
+    IrrSource {
+        name: "CANARIE",
+        display_name: "CANARIE",
+        authoritative: false,
+        transport: Transport::Https,
+        format: DumpFormat::WholeDb,
+    },
+    IrrSource {
+        name: "REACH",
+        display_name: "Telstra Global",
+        authoritative: false,
+        transport: Transport::Ftp,
+        format: DumpFormat::WholeDb,
+    },
+];

--- a/src/irr/sources.rs
+++ b/src/irr/sources.rs
@@ -4,6 +4,7 @@
 //! (HTTPS/FTP) and format (split files vs whole-DB) each one uses.
 
 use crate::irr::IrrObjectType;
+use crate::{BgpkitCommonsError, Result};
 
 /// The transport used to fetch a dump file.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -169,6 +170,25 @@ pub fn default_sources() -> Vec<IrrSource> {
 /// Look up a source by name (case-sensitive, as used in the RPSL `source:` attribute).
 pub fn source_by_name(name: &str) -> Option<IrrSource> {
     SOURCES.iter().find(|s| s.name == name).cloned()
+}
+
+/// Resolve an ordered, deduplicated list of source names.
+///
+/// Every requested name must exist in the catalog; unknown names are errors
+/// rather than silently producing a smaller source selection.
+pub fn sources_by_name(names: &[&str]) -> Result<Vec<IrrSource>> {
+    let mut selected = Vec::with_capacity(names.len());
+    let mut seen = std::collections::HashSet::new();
+    for name in names {
+        if !seen.insert(*name) {
+            continue;
+        }
+        let source = source_by_name(name).ok_or_else(|| {
+            BgpkitCommonsError::invalid_format("IRR source", *name, "unknown registry name")
+        })?;
+        selected.push(source);
+    }
+    Ok(selected)
 }
 
 const DEFAULT_SOURCES: &[IrrSource] = &[

--- a/src/irr/stream.rs
+++ b/src/irr/stream.rs
@@ -12,7 +12,8 @@ use std::io::{BufRead, BufReader, Read};
 
 use tracing::{info, warn};
 
-use crate::irr::sources::{DumpFormat, IrrDumpUrl};
+use crate::irr::sources::{DumpFormat, IrrDumpUrl, IrrSource, source_by_name};
+use crate::irr::types::IrrObjectType;
 use crate::irr::types::{IrrAttribute, IrrObject, IrrRecord};
 use crate::{BgpkitCommonsError, Result};
 
@@ -32,18 +33,27 @@ pub struct ParseStats {
 /// Streaming iterator over source-faithful RPSL records.
 pub struct IrrRecordIter<R: Read> {
     reader: BufReader<R>,
+    format: DumpFormat,
     line: Vec<u8>,
     object_lines: Vec<String>,
     finished: bool,
 }
 
 /// Parse source-faithful RPSL records from a caller-provided reader.
-pub fn parse_reader<R: Read>(reader: R) -> IrrRecordIter<R> {
+pub fn parse_reader<R: Read>(reader: R, format: DumpFormat) -> IrrRecordIter<R> {
     IrrRecordIter {
         reader: BufReader::new(reader),
+        format,
         line: Vec::new(),
         object_lines: Vec::new(),
         finished: false,
+    }
+}
+
+impl<R: Read> IrrRecordIter<R> {
+    /// Return the publication format associated with this record stream.
+    pub fn format(&self) -> DumpFormat {
+        self.format
     }
 }
 
@@ -163,12 +173,44 @@ where
     F: FnMut(IrrObject),
 {
     info!("parsing IRR dump: {}", dump_url.url);
-    let reader = fetch(dump_url)?;
+    let reader = fetch_dump_url(dump_url)?;
     parse_dump_from_reader(reader, dump_url.format, &mut handler)
 }
 
-/// Open an IRR dump for caller-controlled streaming parsing.
-pub fn fetch(dump_url: &IrrDumpUrl) -> Result<Box<dyn Read>> {
+/// Reader returned by [`fetch`], including the selected dump metadata.
+pub struct IrrReader {
+    /// Canonical catalog URL and publication format selected for this reader.
+    pub dump_url: IrrDumpUrl,
+    reader: Box<dyn Read>,
+}
+
+impl Read for IrrReader {
+    fn read(&mut self, buffer: &mut [u8]) -> std::io::Result<usize> {
+        self.reader.read(buffer)
+    }
+}
+
+/// Validate a catalog source and open its dump for an object type.
+pub fn fetch(source: &IrrSource, object_type: IrrObjectType) -> Result<IrrReader> {
+    let source = source_by_name(source.name).ok_or_else(|| {
+        BgpkitCommonsError::invalid_format("IRR source", source.name, "unknown registry name")
+    })?;
+    let dump_url = source
+        .dump_urls(object_type)
+        .into_iter()
+        .next()
+        .ok_or_else(|| {
+            BgpkitCommonsError::invalid_format(
+                "IRR dump",
+                source.name,
+                format!("no dump for {}", object_type.key_attr()),
+            )
+        })?;
+    let reader = fetch_dump_url(&dump_url)?;
+    Ok(IrrReader { dump_url, reader })
+}
+
+fn fetch_dump_url(dump_url: &IrrDumpUrl) -> Result<Box<dyn Read>> {
     Ok(oneio::get_reader(&dump_url.url)?)
 }
 
@@ -182,8 +224,7 @@ where
     F: FnMut(IrrObject),
 {
     let mut stats = ParseStats::default();
-    let _ = format;
-    for record in parse_reader(reader) {
+    for record in parse_reader(reader, format) {
         stats.total_objects += 1;
         match record.and_then(|record| record.to_typed()) {
             Ok(Some(typed)) => {

--- a/src/irr/stream.rs
+++ b/src/irr/stream.rs
@@ -8,15 +8,13 @@
 //! supported type are skipped cheaply (a string comparison on the first
 //! token of each object).
 
-use std::io::{BufRead, BufReader};
+use std::io::{BufRead, BufReader, Read};
 
-use rpsl::parse_object;
 use tracing::{info, warn};
 
-use crate::Result;
-use crate::irr::extract;
 use crate::irr::sources::{DumpFormat, IrrDumpUrl};
-use crate::irr::types::IrrObject;
+use crate::irr::types::{IrrAttribute, IrrObject, IrrRecord};
+use crate::{BgpkitCommonsError, Result};
 
 /// Statistics from a single dump-file parse pass.
 #[derive(Debug, Clone, Default)]
@@ -29,6 +27,111 @@ pub struct ParseStats {
     pub skipped: usize,
     /// Objects that failed extraction with an error.
     pub errors: usize,
+}
+
+/// Streaming iterator over source-faithful RPSL records.
+pub struct IrrRecordIter<R: Read> {
+    reader: BufReader<R>,
+    line: Vec<u8>,
+    object_lines: Vec<String>,
+    finished: bool,
+}
+
+/// Parse source-faithful RPSL records from a caller-provided reader.
+pub fn parse_reader<R: Read>(reader: R) -> IrrRecordIter<R> {
+    IrrRecordIter {
+        reader: BufReader::new(reader),
+        line: Vec::new(),
+        object_lines: Vec::new(),
+        finished: false,
+    }
+}
+
+impl<R: Read> Iterator for IrrRecordIter<R> {
+    type Item = Result<IrrRecord>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.finished {
+            return None;
+        }
+
+        loop {
+            self.line.clear();
+            match self.reader.read_until(b'\n', &mut self.line) {
+                Err(error) => {
+                    self.finished = true;
+                    return Some(Err(error.into()));
+                }
+                Ok(0) => {
+                    self.finished = true;
+                    if self.object_lines.is_empty() {
+                        return None;
+                    }
+                    return Some(parse_record_lines(std::mem::take(&mut self.object_lines)));
+                }
+                Ok(_) => {}
+            }
+
+            let line = String::from_utf8_lossy(&self.line);
+            let line = line.trim_end_matches(['\n', '\r']);
+            if line.trim().is_empty() || line.starts_with('#') || line.starts_with('%') {
+                if self.object_lines.is_empty() {
+                    continue;
+                }
+                return Some(parse_record_lines(std::mem::take(&mut self.object_lines)));
+            }
+            self.object_lines.push(line.to_string());
+        }
+    }
+}
+
+fn parse_record_lines(lines: Vec<String>) -> Result<IrrRecord> {
+    let mut attributes: Vec<IrrAttribute> = Vec::new();
+    for line in lines {
+        if line.starts_with(char::is_whitespace) {
+            let Some(attribute) = attributes.last_mut() else {
+                return Err(BgpkitCommonsError::invalid_format(
+                    "RPSL object",
+                    line,
+                    "continuation line without an attribute",
+                ));
+            };
+            attribute.value.push('\n');
+            attribute.value.push_str(line.trim());
+            continue;
+        }
+
+        let Some((name, value)) = line.split_once(':') else {
+            return Err(BgpkitCommonsError::invalid_format(
+                "RPSL object",
+                line,
+                "attribute line is missing ':'",
+            ));
+        };
+        let name = name.trim();
+        if name.is_empty() {
+            return Err(BgpkitCommonsError::invalid_format(
+                "RPSL object",
+                line,
+                "attribute name is empty",
+            ));
+        }
+        attributes.push(IrrAttribute {
+            name: name.to_string(),
+            value: value.trim().to_string(),
+        });
+    }
+
+    let object_type = attributes
+        .first()
+        .map(|attribute| attribute.name.clone())
+        .ok_or_else(|| {
+            BgpkitCommonsError::invalid_format("RPSL object", "", "object has no attributes")
+        })?;
+    Ok(IrrRecord {
+        object_type,
+        attributes,
+    })
 }
 
 impl std::fmt::Display for ParseStats {
@@ -60,8 +163,13 @@ where
     F: FnMut(IrrObject),
 {
     info!("parsing IRR dump: {}", dump_url.url);
-    let reader = oneio::get_reader(&dump_url.url)?;
+    let reader = fetch(dump_url)?;
     parse_dump_from_reader(reader, dump_url.format, &mut handler)
+}
+
+/// Open an IRR dump for caller-controlled streaming parsing.
+pub fn fetch(dump_url: &IrrDumpUrl) -> Result<Box<dyn Read>> {
+    Ok(oneio::get_reader(&dump_url.url)?)
 }
 
 /// Parse a dump file from any reader (for testing or custom I/O).
@@ -73,112 +181,25 @@ pub fn parse_dump_from_reader<R: std::io::Read, F>(
 where
     F: FnMut(IrrObject),
 {
-    let buf_reader = BufReader::new(reader);
     let mut stats = ParseStats::default();
-
-    // RPSL objects are separated by blank lines.
-    // Comment lines (starting with # or %) are outside objects.
-    // Continuation lines start with whitespace (tab/space+).
-    //
-    // We use read_until instead of lines() because IRR dumps occasionally
-    // contain non-UTF-8 bytes (latin-1 etc.). We lossily convert to String.
-    let mut chunk = String::new();
-    let mut in_object = false;
-
-    let mut buf = Vec::new();
-    let mut reader = buf_reader;
-
-    loop {
-        buf.clear();
-        let n = reader.read_until(b'\n', &mut buf)?;
-        if n == 0 {
-            break;
-        }
-        // Lossily convert to handle non-UTF-8 bytes in legacy IRR data
-        let line = String::from_utf8_lossy(&buf);
-        let line = line.trim_end_matches('\n').trim_end_matches('\r');
-
-        if line.trim().is_empty() {
-            // Blank line: end of current object
-            if in_object && !chunk.is_empty() {
-                process_chunk(&chunk, format, handler, &mut stats);
-                chunk.clear();
-                in_object = false;
+    let _ = format;
+    for record in parse_reader(reader) {
+        stats.total_objects += 1;
+        match record.and_then(|record| record.to_typed()) {
+            Ok(Some(typed)) => {
+                stats.extracted += 1;
+                handler(typed);
             }
-            continue;
-        }
-
-        if line.starts_with('#') || line.starts_with('%') {
-            // Comment line: only ends an object if we're in one
-            if in_object && !chunk.is_empty() {
-                process_chunk(&chunk, format, handler, &mut stats);
-                chunk.clear();
-                in_object = false;
+            Ok(None) => stats.skipped += 1,
+            Err(error) => {
+                stats.errors += 1;
+                warn!("IRR parse error: {error}");
             }
-            continue;
         }
-
-        in_object = true;
-        chunk.push_str(line);
-        chunk.push('\n');
-    }
-
-    // Process trailing object (no blank line at EOF)
-    if !chunk.is_empty() {
-        process_chunk(&chunk, format, handler, &mut stats);
     }
 
     info!("IRR dump parsed: {}", stats);
     Ok(stats)
-}
-
-fn process_chunk<F>(chunk: &str, _format: DumpFormat, handler: &mut F, stats: &mut ParseStats)
-where
-    F: FnMut(IrrObject),
-{
-    stats.total_objects += 1;
-
-    // Quick check: skip comment-only chunks
-    let trimmed = chunk.trim();
-    if trimmed.is_empty() || trimmed.starts_with('#') {
-        stats.skipped += 1;
-        return;
-    }
-
-    // rpsl::parse_object requires a trailing blank line to delimit the object.
-    // Ensure the chunk ends with "\n\n".
-    let owned;
-    let text = if chunk.ends_with("\n\n") {
-        chunk
-    } else {
-        owned = format!("{chunk}\n");
-        &owned
-    };
-
-    let parsed = match parse_object(text) {
-        Ok(obj) => obj,
-        Err(e) => {
-            stats.errors += 1;
-            // Only log first few chars for debugging
-            let preview: String = chunk.chars().take(80).collect();
-            warn!("RPSL parse error: {e} (preview: {preview}...)");
-            return;
-        }
-    };
-
-    match extract::extract(&parsed) {
-        Ok(Some(typed)) => {
-            stats.extracted += 1;
-            handler(typed);
-        }
-        Ok(None) => {
-            stats.skipped += 1;
-        }
-        Err(e) => {
-            stats.errors += 1;
-            warn!("IRR extract error: {e}");
-        }
-    }
 }
 
 #[cfg(test)]

--- a/src/irr/stream.rs
+++ b/src/irr/stream.rs
@@ -1,0 +1,332 @@
+//! Streaming parser for IRR bulk dump files.
+//!
+//! Reads gzipped RPSL text from a URL (via oneio), splits it into
+//! per-object chunks at blank lines, parses each with `rpsl::parse_object`,
+//! and extracts typed [`IrrObject`]s via [`crate::irr::extract`].
+//!
+//! For `WholeDb` dumps, objects whose first attribute doesn't match any
+//! supported type are skipped cheaply (a string comparison on the first
+//! token of each object).
+
+use std::io::{BufRead, BufReader};
+
+use rpsl::parse_object;
+use tracing::{info, warn};
+
+use crate::Result;
+use crate::irr::extract;
+use crate::irr::sources::{DumpFormat, IrrDumpUrl};
+use crate::irr::types::IrrObject;
+
+/// Statistics from a single dump-file parse pass.
+#[derive(Debug, Clone, Default)]
+pub struct ParseStats {
+    /// Total RPSL objects encountered (including skipped ones).
+    pub total_objects: usize,
+    /// Objects successfully extracted as typed IRR objects.
+    pub extracted: usize,
+    /// Objects skipped (unsupported type or parse error).
+    pub skipped: usize,
+    /// Objects that failed extraction with an error.
+    pub errors: usize,
+}
+
+impl std::fmt::Display for ParseStats {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "{} extracted, {} skipped, {} errors (of {} total)",
+            self.extracted, self.skipped, self.errors, self.total_objects
+        )
+    }
+}
+
+/// Parse a single dump file and call `handler` for each extracted object.
+///
+/// The handler receives each [`IrrObject`] and can collect, filter, or
+/// process them as needed. This is the core building block for all
+/// IRR data loading.
+///
+/// # Arguments
+///
+/// * `dump_url` — The dump file descriptor (URL, transport, format).
+/// * `handler` — A closure called for each successfully extracted object.
+///
+/// # Errors
+///
+/// Returns an error if the file cannot be opened or read.
+pub fn parse_dump<F>(dump_url: &IrrDumpUrl, mut handler: F) -> Result<ParseStats>
+where
+    F: FnMut(IrrObject),
+{
+    info!("parsing IRR dump: {}", dump_url.url);
+    let reader = oneio::get_reader(&dump_url.url)?;
+    parse_dump_from_reader(reader, dump_url.format, &mut handler)
+}
+
+/// Parse a dump file from any reader (for testing or custom I/O).
+pub fn parse_dump_from_reader<R: std::io::Read, F>(
+    reader: R,
+    format: DumpFormat,
+    handler: &mut F,
+) -> Result<ParseStats>
+where
+    F: FnMut(IrrObject),
+{
+    let buf_reader = BufReader::new(reader);
+    let mut stats = ParseStats::default();
+
+    // RPSL objects are separated by blank lines.
+    // Comment lines (starting with # or %) are outside objects.
+    // Continuation lines start with whitespace (tab/space+).
+    //
+    // We use read_until instead of lines() because IRR dumps occasionally
+    // contain non-UTF-8 bytes (latin-1 etc.). We lossily convert to String.
+    let mut chunk = String::new();
+    let mut in_object = false;
+
+    let mut buf = Vec::new();
+    let mut reader = buf_reader;
+
+    loop {
+        buf.clear();
+        let n = reader.read_until(b'\n', &mut buf)?;
+        if n == 0 {
+            break;
+        }
+        // Lossily convert to handle non-UTF-8 bytes in legacy IRR data
+        let line = String::from_utf8_lossy(&buf);
+        let line = line.trim_end_matches('\n').trim_end_matches('\r');
+
+        if line.trim().is_empty() {
+            // Blank line: end of current object
+            if in_object && !chunk.is_empty() {
+                process_chunk(&chunk, format, handler, &mut stats);
+                chunk.clear();
+                in_object = false;
+            }
+            continue;
+        }
+
+        if line.starts_with('#') || line.starts_with('%') {
+            // Comment line: only ends an object if we're in one
+            if in_object && !chunk.is_empty() {
+                process_chunk(&chunk, format, handler, &mut stats);
+                chunk.clear();
+                in_object = false;
+            }
+            continue;
+        }
+
+        in_object = true;
+        chunk.push_str(line);
+        chunk.push('\n');
+    }
+
+    // Process trailing object (no blank line at EOF)
+    if !chunk.is_empty() {
+        process_chunk(&chunk, format, handler, &mut stats);
+    }
+
+    info!("IRR dump parsed: {}", stats);
+    Ok(stats)
+}
+
+fn process_chunk<F>(chunk: &str, _format: DumpFormat, handler: &mut F, stats: &mut ParseStats)
+where
+    F: FnMut(IrrObject),
+{
+    stats.total_objects += 1;
+
+    // Quick check: skip comment-only chunks
+    let trimmed = chunk.trim();
+    if trimmed.is_empty() || trimmed.starts_with('#') {
+        stats.skipped += 1;
+        return;
+    }
+
+    // rpsl::parse_object requires a trailing blank line to delimit the object.
+    // Ensure the chunk ends with "\n\n".
+    let owned;
+    let text = if chunk.ends_with("\n\n") {
+        chunk
+    } else {
+        owned = format!("{chunk}\n");
+        &owned
+    };
+
+    let parsed = match parse_object(text) {
+        Ok(obj) => obj,
+        Err(e) => {
+            stats.errors += 1;
+            // Only log first few chars for debugging
+            let preview: String = chunk.chars().take(80).collect();
+            warn!("RPSL parse error: {e} (preview: {preview}...)");
+            return;
+        }
+    };
+
+    match extract::extract(&parsed) {
+        Ok(Some(typed)) => {
+            stats.extracted += 1;
+            handler(typed);
+        }
+        Ok(None) => {
+            stats.skipped += 1;
+        }
+        Err(e) => {
+            stats.errors += 1;
+            warn!("IRR extract error: {e}");
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::irr::types::IrrObject;
+    use std::io::Cursor;
+
+    const SAMPLE_RIPE_AUTNUM: &str = "\
+aut-num:        AS13335
+as-name:        CLOUDFLARENET
+descr:          Cloudflare, Inc.
+org:            ORG-CF165-RIPE
+mnt-by:         CLOUDFLARE-MNT
+source:         RIPE
+
+aut-num:        AS15169
+as-name:        GOOGLE
+descr:          Google LLC
+source:         RIPE
+
+route:          1.1.1.0/24
+origin:         AS13335
+descr:          Cloudflare
+source:         RIPE
+";
+
+    #[test]
+    fn test_parse_aut_num_and_route() {
+        let mut objects = Vec::new();
+        let stats = parse_dump_from_reader(
+            Cursor::new(SAMPLE_RIPE_AUTNUM),
+            DumpFormat::SplitFiles,
+            &mut |obj| objects.push(obj),
+        )
+        .unwrap();
+
+        assert_eq!(stats.total_objects, 3);
+        assert_eq!(stats.extracted, 3);
+        assert_eq!(stats.skipped, 0);
+        assert_eq!(stats.errors, 0);
+
+        // First: aut-num AS13335
+        match &objects[0] {
+            IrrObject::AutNum(a) => {
+                assert_eq!(a.asn, 13335);
+                assert_eq!(a.as_name, "CLOUDFLARENET");
+                assert_eq!(a.source, "RIPE");
+                assert!(a.descr.iter().any(|d| d.contains("Cloudflare")));
+            }
+            other => panic!("expected AutNum, got {other:?}"),
+        }
+
+        // Second: aut-num AS15169
+        match &objects[1] {
+            IrrObject::AutNum(a) => {
+                assert_eq!(a.asn, 15169);
+                assert_eq!(a.as_name, "GOOGLE");
+            }
+            other => panic!("expected AutNum, got {other:?}"),
+        }
+
+        // Third: route 1.1.1.0/24
+        match &objects[2] {
+            IrrObject::Route(r) => {
+                assert_eq!(r.prefix.to_string(), "1.1.1.0/24");
+                assert_eq!(r.origin, 13335);
+            }
+            other => panic!("expected Route, got {other:?}"),
+        }
+    }
+
+    const SAMPLE_ASSET: &str = "\
+as-set:         AS-EXAMPLE
+descr:          Example AS set
+members:        AS64496, AS64497
+members:        AS-EXAMPLE-CLIENTS
+members:        AS64500
+source:         RIPE
+";
+
+    #[test]
+    fn test_parse_as_set() {
+        let mut objects = Vec::new();
+        parse_dump_from_reader(
+            Cursor::new(SAMPLE_ASSET),
+            DumpFormat::SplitFiles,
+            &mut |obj| objects.push(obj),
+        )
+        .unwrap();
+
+        assert_eq!(objects.len(), 1);
+        match &objects[0] {
+            IrrObject::AsSet(s) => {
+                assert_eq!(s.name, "AS-EXAMPLE");
+                assert_eq!(s.members, vec![64496, 64497, 64500]);
+                assert_eq!(s.set_members, vec!["AS-EXAMPLE-CLIENTS"]);
+            }
+            other => panic!("expected AsSet, got {other:?}"),
+        }
+    }
+
+    const SAMPLE_WITH_COMMENTS: &str = "\
+# This is a comment
+# Another comment
+
+aut-num:        AS3356
+as-name:        LEVEL3
+source:         RIPE
+";
+
+    #[test]
+    fn test_skip_comments() {
+        let mut objects = Vec::new();
+        let stats = parse_dump_from_reader(
+            Cursor::new(SAMPLE_WITH_COMMENTS),
+            DumpFormat::SplitFiles,
+            &mut |obj| objects.push(obj),
+        )
+        .unwrap();
+
+        assert_eq!(objects.len(), 1);
+        assert_eq!(stats.extracted, 1);
+    }
+
+    const SAMPLE_SKIP_UNKNOWN: &str = "\
+person:         John Doe
+nic-hdl:        JD-RIPE
+source:         RIPE
+
+aut-num:        AS1299
+as-name:        TWELVE99
+source:         RIPE
+";
+
+    #[test]
+    fn test_skip_unknown_types() {
+        let mut objects = Vec::new();
+        let stats = parse_dump_from_reader(
+            Cursor::new(SAMPLE_SKIP_UNKNOWN),
+            DumpFormat::WholeDb,
+            &mut |obj| objects.push(obj),
+        )
+        .unwrap();
+
+        assert_eq!(objects.len(), 1);
+        assert_eq!(stats.total_objects, 2);
+        assert_eq!(stats.extracted, 1);
+        assert_eq!(stats.skipped, 1);
+    }
+}

--- a/src/irr/types.rs
+++ b/src/irr/types.rs
@@ -1,0 +1,207 @@
+//! Typed RPSL object representations for IRR data.
+//!
+//! Each struct corresponds to a specific RPSL object type. Fields are
+//! extracted from parsed `rpsl::Object<Raw>` instances and stored as owned
+//! data so the original text can be dropped.
+
+use std::collections::BTreeMap;
+
+use ipnet::IpNet;
+use serde::{Deserialize, Serialize};
+
+/// RPSL object types that this module knows how to extract.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum IrrObjectType {
+    /// `aut-num` — AS name/description/maintainer.
+    AutNum,
+    /// `route` — IPv4 prefix-origin registration.
+    Route,
+    /// `route6` — IPv6 prefix-origin registration.
+    Route6,
+    /// `as-set` — named group of ASes (may be recursive).
+    AsSet,
+    /// `route-set` — named group of prefixes.
+    RouteSet,
+    /// `mntner` — maintainer object with auth methods.
+    Mntner,
+    /// `organisation` — organisation details (RIPE) / org (others).
+    Organisation,
+}
+
+impl IrrObjectType {
+    /// The RPSL attribute name that starts an object of this type.
+    /// This is also the key of the first attribute in the parsed object.
+    pub fn key_attr(&self) -> &'static str {
+        match self {
+            IrrObjectType::AutNum => "aut-num",
+            IrrObjectType::Route => "route",
+            IrrObjectType::Route6 => "route6",
+            IrrObjectType::AsSet => "as-set",
+            IrrObjectType::RouteSet => "route-set",
+            IrrObjectType::Mntner => "mntner",
+            IrrObjectType::Organisation => "organisation",
+        }
+    }
+
+    /// Parse the key attribute name from a parsed RPSL object's first
+    /// attribute to determine the object type. Returns `None` for unknown
+    /// or unsupported types.
+    pub fn from_first_attr(name: &str) -> Option<Self> {
+        match name {
+            "aut-num" => Some(IrrObjectType::AutNum),
+            "route" => Some(IrrObjectType::Route),
+            "route6" => Some(IrrObjectType::Route6),
+            "as-set" => Some(IrrObjectType::AsSet),
+            "route-set" => Some(IrrObjectType::RouteSet),
+            "mntner" => Some(IrrObjectType::Mntner),
+            "organisation" | "org" => Some(IrrObjectType::Organisation),
+            _ => None,
+        }
+    }
+
+    /// Returns all supported object types.
+    pub fn all() -> &'static [IrrObjectType] {
+        &[
+            IrrObjectType::AutNum,
+            IrrObjectType::Route,
+            IrrObjectType::Route6,
+            IrrObjectType::AsSet,
+            IrrObjectType::RouteSet,
+            IrrObjectType::Mntner,
+            IrrObjectType::Organisation,
+        ]
+    }
+}
+
+// ============================================================================
+// Typed RPSL Objects
+// ============================================================================
+
+/// An `aut-num` object: AS-level routing registry entry.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AutNum {
+    /// The AS number, e.g. `13335`.
+    pub asn: u32,
+    /// The `as-name` attribute.
+    pub as_name: String,
+    /// The `descr` attributes (may be multiple).
+    pub descr: Vec<String>,
+    /// The `source` attribute (registry provenance).
+    pub source: String,
+    /// All other attributes as (name, value) pairs, preserving order.
+    pub extra: BTreeMap<String, Vec<String>>,
+}
+
+/// A `route` or `route6` object: prefix-origin registration.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Route {
+    /// The registered prefix.
+    pub prefix: IpNet,
+    /// The origin AS number.
+    pub origin: u32,
+    /// The `descr` attributes.
+    pub descr: Vec<String>,
+    /// The `source` attribute (registry provenance).
+    pub source: String,
+    /// All other attributes.
+    pub extra: BTreeMap<String, Vec<String>>,
+}
+
+/// An `as-set` object: named collection of ASes and/or other as-sets.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AsSet {
+    /// The as-set name, e.g. `AS-EXAMPLE`.
+    pub name: String,
+    /// Direct AS members (numeric).
+    pub members: Vec<u32>,
+    /// AS-set members (named references, may require recursive resolution).
+    pub set_members: Vec<String>,
+    /// The `descr` attributes.
+    pub descr: Vec<String>,
+    /// The `source` attribute.
+    pub source: String,
+    /// All other attributes.
+    pub extra: BTreeMap<String, Vec<String>>,
+}
+
+/// A `route-set` object: named collection of prefixes and/or other route-sets.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RouteSet {
+    /// The route-set name, e.g. `RS-EXAMPLE`.
+    pub name: String,
+    /// Direct prefix members.
+    pub members: Vec<IpNet>,
+    /// Route-set members (named references, may require recursive resolution).
+    pub set_members: Vec<String>,
+    /// The `descr` attributes.
+    pub descr: Vec<String>,
+    /// The `source` attribute.
+    pub source: String,
+    /// All other attributes.
+    pub extra: BTreeMap<String, Vec<String>>,
+}
+
+/// A `mntner` object: database maintainer with authentication info.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Mntner {
+    /// The maintainer name, e.g. `MAINT-AS13335`.
+    pub name: String,
+    /// Authentication methods declared (e.g. `MD5-PW`, `PGPKEY-...`).
+    /// Values are kept verbatim but passwords are always stripped by IRR dumps.
+    pub auth: Vec<String>,
+    /// The `upd-to` notification email.
+    pub upd_to: Vec<String>,
+    /// The `mnt-nfy` notification email.
+    pub mnt_nfy: Vec<String>,
+    /// The `source` attribute.
+    pub source: String,
+    /// All other attributes.
+    pub extra: BTreeMap<String, Vec<String>>,
+}
+
+/// An `organisation` (or `org`) object: entity details.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Organisation {
+    /// The organisation ID, e.g. `ORG-GCI2-RIPE`.
+    pub id: String,
+    /// The organisation name.
+    pub name: String,
+    /// The organisation type (RIPE-specific, e.g. `LIR`, `RIR`).
+    pub org_type: Option<String>,
+    /// Address lines.
+    pub address: Vec<String>,
+    /// Country code.
+    pub country: Option<String>,
+    /// Abuse contact email.
+    pub abuse_c: Option<String>,
+    /// The `source` attribute.
+    pub source: String,
+    /// All other attributes.
+    pub extra: BTreeMap<String, Vec<String>>,
+}
+
+/// A typed IRR object, tagged by its type.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum IrrObject {
+    AutNum(AutNum),
+    Route(Route),
+    Route6(Route),
+    AsSet(AsSet),
+    RouteSet(RouteSet),
+    Mntner(Mntner),
+    Organisation(Organisation),
+}
+
+impl IrrObject {
+    /// The `source:` attribute value (registry provenance).
+    pub fn source(&self) -> &str {
+        match self {
+            IrrObject::AutNum(o) => &o.source,
+            IrrObject::Route(o) | IrrObject::Route6(o) => &o.source,
+            IrrObject::AsSet(o) => &o.source,
+            IrrObject::RouteSet(o) => &o.source,
+            IrrObject::Mntner(o) => &o.source,
+            IrrObject::Organisation(o) => &o.source,
+        }
+    }
+}

--- a/src/irr/types.rs
+++ b/src/irr/types.rs
@@ -9,6 +9,53 @@ use std::collections::BTreeMap;
 use ipnet::IpNet;
 use serde::{Deserialize, Serialize};
 
+use crate::irr::extract;
+use crate::{BgpkitCommonsError, Result};
+
+/// One ordered RPSL attribute from an IRR source record.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct IrrAttribute {
+    pub name: String,
+    pub value: String,
+}
+
+/// One source-faithful RPSL object.
+///
+/// Attributes remain ordered and repeated attributes remain separate. The
+/// record is not restricted to the object classes with typed projections.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct IrrRecord {
+    pub object_type: String,
+    pub attributes: Vec<IrrAttribute>,
+}
+
+impl IrrRecord {
+    /// Convert a supported raw record to the existing typed representation.
+    /// Unsupported object classes return `Ok(None)`.
+    pub fn to_typed(&self) -> Result<Option<IrrObject>> {
+        let mut text = String::new();
+        for attribute in &self.attributes {
+            let mut values = attribute.value.split('\n');
+            let first = values.next().unwrap_or_default();
+            text.push_str(&attribute.name);
+            text.push_str(": ");
+            text.push_str(first);
+            text.push('\n');
+            for continuation in values {
+                text.push(' ');
+                text.push_str(continuation);
+                text.push('\n');
+            }
+        }
+        text.push('\n');
+
+        let parsed = rpsl::parse_object(&text).map_err(|error| {
+            BgpkitCommonsError::invalid_format("RPSL object", &self.object_type, error.to_string())
+        })?;
+        extract::extract(&parsed)
+    }
+}
+
 /// RPSL object types that this module knows how to extract.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum IrrObjectType {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -106,7 +106,7 @@
 //! use bgpkit_commons::BgpkitCommons;
 //!
 //! let mut commons = BgpkitCommons::new();
-//! commons.load_asinfo(false, false, false, false).unwrap();
+//! commons.load_asinfo_with_profile(Default::default()).unwrap();
 //! commons.load_countries().unwrap();
 //!
 //! if let Ok(Some(asinfo)) = commons.asinfo_get(13335) {
@@ -211,6 +211,8 @@ pub mod asinfo;
 pub mod bogons;
 #[cfg(feature = "countries")]
 pub mod countries;
+#[cfg(feature = "irr")]
+pub mod irr;
 #[cfg(feature = "mrt_collectors")]
 pub mod mrt_collectors;
 #[cfg(feature = "peeringdb")]
@@ -520,21 +522,31 @@ impl BgpkitCommons {
         Ok(())
     }
 
-    /// Load AS name and country data
+    /// Load AS information using a loading profile.
+    ///
+    /// Profiles provide curated presets for common use cases:
+    /// - [`Minimum`](crate::asinfo::AsInfoProfile::Minimum): asn.txt only (~1s)
+    /// - [`Default`](crate::asinfo::AsInfoProfile::Default): + as2org, population, hegemony, peeringdb (~30s)
+    /// - [`Full`](crate::asinfo::AsInfoProfile::Full): + delegated stats, IRR data with route prefixes (~75s)
+    ///
+    /// For fine-grained control beyond these presets, use the builder via
+    /// [`BgpkitCommons::asinfo_builder`].
+    ///
+    /// # Example
+    ///
+    /// ```rust,no_run
+    /// use bgpkit_commons::asinfo::AsInfoProfile;
+    /// use bgpkit_commons::BgpkitCommons;
+    ///
+    /// let mut commons = BgpkitCommons::new();
+    /// commons.load_asinfo_with_profile(AsInfoProfile::Default).unwrap();
+    /// ```
     #[cfg(feature = "asinfo")]
-    pub fn load_asinfo(
+    pub fn load_asinfo_with_profile(
         &mut self,
-        load_as2org: bool,
-        load_population: bool,
-        load_hegemony: bool,
-        load_peeringdb: bool,
+        profile: crate::asinfo::AsInfoProfile,
     ) -> Result<()> {
-        self.asinfo = Some(crate::asinfo::AsInfoUtils::new(
-            load_as2org,
-            load_population,
-            load_hegemony,
-            load_peeringdb,
-        )?);
+        self.asinfo = Some(profile.builder().build()?);
         Ok(())
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -553,6 +553,39 @@ impl BgpkitCommons {
         Ok(())
     }
 
+    /// Load AS name and country data with optional enrichment sources.
+    ///
+    /// Compatibility shim retained from the pre-v0.12 boolean-argument API.
+    /// Maps to the equivalent [`AsInfoBuilder`](crate::asinfo::AsInfoBuilder)
+    /// configuration with identical behavior. Prefer
+    /// [`BgpkitCommons::load_asinfo_with_profile`] or
+    /// [`BgpkitCommons::load_asinfo_with`].
+    #[cfg(feature = "asinfo")]
+    #[deprecated(note = "use load_asinfo_with_profile() or load_asinfo_with() instead")]
+    pub fn load_asinfo(
+        &mut self,
+        load_as2org: bool,
+        load_population: bool,
+        load_hegemony: bool,
+        load_peeringdb: bool,
+    ) -> Result<()> {
+        let mut builder = crate::asinfo::AsInfoBuilder::new();
+        if load_as2org {
+            builder = builder.with_as2org();
+        }
+        if load_population {
+            builder = builder.with_population();
+        }
+        if load_hegemony {
+            builder = builder.with_hegemony();
+        }
+        if load_peeringdb {
+            builder = builder.with_peeringdb();
+        }
+        self.asinfo = Some(builder.build()?);
+        Ok(())
+    }
+
     #[cfg(feature = "asinfo")]
     pub fn load_asinfo_cached(&mut self) -> Result<()> {
         self.asinfo = Some(crate::asinfo::AsInfoUtils::new_from_cached()?);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -213,6 +213,9 @@ pub mod bogons;
 pub mod countries;
 #[cfg(feature = "irr")]
 pub mod irr;
+
+#[cfg(feature = "delegated")]
+pub mod delegated;
 #[cfg(feature = "mrt_collectors")]
 pub mod mrt_collectors;
 #[cfg(feature = "peeringdb")]

--- a/tests/asinfo_integration.rs
+++ b/tests/asinfo_integration.rs
@@ -8,7 +8,7 @@ fn test_basic_info() {
 
     // Load AS information (core asn.txt only).
     commons
-        .load_asinfo_with_profile(Default::default())
+        .load_asinfo_with_profile(bgpkit_commons::asinfo::AsInfoProfile::Minimum)
         .unwrap();
 
     // Assert that the AS name for AS number 3333 is correct.
@@ -80,9 +80,6 @@ fn test_loading_cached() {
 #[ignore = "network: downloads asn.txt + delegated stats + IRR dumps (~80MB total)"]
 fn test_irr_and_delegated_enrichment() {
     let mut commons = bgpkit_commons::BgpkitCommons::new();
-    commons
-        .load_asinfo_with_profile(bgpkit_commons::asinfo::AsInfoProfile::Full)
-        .unwrap();
     commons
         .load_asinfo_with_profile(bgpkit_commons::asinfo::AsInfoProfile::Full)
         .unwrap();

--- a/tests/asinfo_integration.rs
+++ b/tests/asinfo_integration.rs
@@ -117,7 +117,9 @@ fn test_irr_and_delegated_enrichment() {
             "AS13335 should have route prefixes from RADB"
         );
         assert!(
-            radb.route_prefixes.iter().any(|p| p.starts_with("1.1.1.")),
+            radb.route_prefixes
+                .iter()
+                .any(|prefix| prefix.addr().octets().starts_with(&[1, 1, 1])),
             "AS13335 RADB routes should include 1.1.1.x, got: {:?}",
             radb.route_prefixes.iter().take(5).collect::<Vec<_>>()
         );

--- a/tests/asinfo_integration.rs
+++ b/tests/asinfo_integration.rs
@@ -6,9 +6,10 @@ fn test_basic_info() {
     // Create a new instance of BgpkitCommons.
     let mut commons = bgpkit_commons::BgpkitCommons::new();
 
-    // Load AS information with default parameters.
-    // no as2org, no population data, no as-hegemony
-    commons.load_asinfo(false, false, false, false).unwrap();
+    // Load AS information (core asn.txt only).
+    commons
+        .load_asinfo_with_profile(Default::default())
+        .unwrap();
 
     // Assert that the AS name for AS number 3333 is correct.
     assert_eq!(
@@ -70,5 +71,102 @@ fn test_loading_cached() {
     assert_eq!(
         bgpkit_info.peeringdb.unwrap().irr_as_set.unwrap(),
         "AS400644:AS-BGPKIT"
+    );
+}
+
+/// Verify IRR enrichment: per-source arrays, route prefixes, as-set memberships,
+/// delegated data on all ASNs, and UNKNOWN name fill.
+#[test]
+#[ignore = "network: downloads asn.txt + delegated stats + IRR dumps (~80MB total)"]
+fn test_irr_and_delegated_enrichment() {
+    let mut commons = bgpkit_commons::BgpkitCommons::new();
+    commons
+        .load_asinfo_with_profile(bgpkit_commons::asinfo::AsInfoProfile::Full)
+        .unwrap();
+    commons
+        .load_asinfo_with_profile(bgpkit_commons::asinfo::AsInfoProfile::Full)
+        .unwrap();
+    let cf = commons.asinfo_get(13335).unwrap().unwrap();
+    assert!(cf.delegated.is_some(), "AS13335 should have delegated data");
+    let del = cf.delegated.as_ref().unwrap();
+    assert_eq!(del.country, "US");
+    assert!(!del.registry.is_empty());
+    assert!(!del.status.is_empty());
+
+    // === Per-source IRR arrays ===
+    assert!(
+        !cf.irr.is_empty(),
+        "AS13335 should have IRR data from at least one source"
+    );
+    // Find the RIPE source entry
+    let ripe_entry = cf.irr.iter().find(|i| i.source == "RIPE");
+    assert!(ripe_entry.is_some(), "AS13335 should have RIPE IRR entry");
+    let ripe = ripe_entry.unwrap();
+    assert!(
+        ripe.as_name.contains("CLOUDFLARE"),
+        "AS13335 RIPE as_name should contain CLOUDFLARE, got: {}",
+        ripe.as_name
+    );
+
+    // === Route prefixes ===
+    // AS13335 should have route prefixes from RADB (1.1.1.0/24 etc.)
+    let radb_entry = cf.irr.iter().find(|i| i.source == "RADB");
+    if let Some(radb) = radb_entry {
+        assert!(
+            !radb.route_prefixes.is_empty(),
+            "AS13335 should have route prefixes from RADB"
+        );
+        assert!(
+            radb.route_prefixes.iter().any(|p| p.starts_with("1.1.1.")),
+            "AS13335 RADB routes should include 1.1.1.x, got: {:?}",
+            radb.route_prefixes.iter().take(5).collect::<Vec<_>>()
+        );
+    }
+
+    // === UNKNOWN name fill ===
+    if let Some(info) = commons.asinfo_get(219125).unwrap() {
+        assert_ne!(
+            info.name, "UNKNOWN",
+            "AS219125 name should be filled from IRR, not UNKNOWN"
+        );
+        let ripe = info.irr.iter().find(|i| i.source == "RIPE");
+        assert!(ripe.is_some(), "AS219125 should have RIPE IRR entry");
+        assert_eq!(ripe.unwrap().as_name, "ACKENS");
+    }
+
+    // === Delegated data on gap ASNs ===
+    if let Some(info) = commons.asinfo_get(219157).unwrap() {
+        assert!(
+            info.delegated.is_some(),
+            "AS219157 should have delegated data"
+        );
+        assert_eq!(info.delegated.as_ref().unwrap().country, "GB");
+    }
+
+    // === Summary counts ===
+    let all = commons.asinfo_all().unwrap();
+    let irr_count = all.values().filter(|i| !i.irr.is_empty()).count();
+    let delegated_count = all.values().filter(|i| i.delegated.is_some()).count();
+    let unknown_count = all.values().filter(|info| info.name == "UNKNOWN").count();
+    let routes_count = all
+        .values()
+        .filter(|i| i.irr.iter().any(|s| !s.route_prefixes.is_empty()))
+        .count();
+    eprintln!("ASNs with IRR data: {irr_count}");
+    eprintln!("ASNs with delegated data: {delegated_count}");
+    eprintln!("ASNs with IRR route prefixes: {routes_count}");
+    eprintln!("ASNs still UNKNOWN: {unknown_count}");
+
+    assert!(
+        irr_count > 50_000,
+        "expected >50k with IRR data, got {irr_count}"
+    );
+    assert!(
+        delegated_count > 120_000,
+        "expected >120k with delegated data, got {delegated_count}"
+    );
+    assert!(
+        unknown_count < 500,
+        "expected <500 UNKNOWN, got {unknown_count}"
     );
 }

--- a/tests/asinfo_serialization.rs
+++ b/tests/asinfo_serialization.rs
@@ -1,0 +1,64 @@
+#![cfg(feature = "asinfo")]
+
+use bgpkit_commons::asinfo::{AsInfo, IrrAsnInfo};
+use ipnet::{Ipv4Net, Ipv6Net};
+use serde_json::{Value, json};
+
+#[test]
+fn old_records_without_new_fields_still_deserialize() {
+    let value = json!({
+        "asn": 13335,
+        "name": "CLOUDFLARENET",
+        "country": "US"
+    });
+
+    let info: AsInfo = serde_json::from_value(value).unwrap();
+    assert!(info.delegated.is_none());
+    assert!(info.irr.is_empty());
+}
+
+#[test]
+fn absent_enrichments_are_omitted_from_serialization() {
+    let info = AsInfo {
+        asn: 13335,
+        name: "CLOUDFLARENET".to_string(),
+        country: "US".to_string(),
+        as2org: None,
+        population: None,
+        hegemony: None,
+        peeringdb: None,
+        delegated: None,
+        irr: Vec::new(),
+    };
+
+    let value = serde_json::to_value(info).unwrap();
+    assert_eq!(
+        value,
+        Value::Object(
+            [
+                ("asn".to_string(), json!(13335)),
+                ("name".to_string(), json!("CLOUDFLARENET")),
+                ("country".to_string(), json!("US")),
+            ]
+            .into_iter()
+            .collect()
+        )
+    );
+}
+
+#[test]
+fn irr_prefixes_are_typed_in_memory_and_cidr_strings_in_json() {
+    let irr = IrrAsnInfo {
+        as_name: "CLOUDFLARENET".to_string(),
+        descr: Vec::new(),
+        source: "RADB".to_string(),
+        mnt_by: Vec::new(),
+        route_prefixes: vec!["1.1.1.0/24".parse::<Ipv4Net>().unwrap()],
+        route6_prefixes: vec!["2606:4700::/32".parse::<Ipv6Net>().unwrap()],
+        member_of_sets: Vec::new(),
+    };
+
+    let value = serde_json::to_value(irr).unwrap();
+    assert_eq!(value["route_prefixes"], json!(["1.1.1.0/24"]));
+    assert_eq!(value["route6_prefixes"], json!(["2606:4700::/32"]));
+}

--- a/tests/delegated_source.rs
+++ b/tests/delegated_source.rs
@@ -1,0 +1,36 @@
+#![cfg(feature = "delegated")]
+
+use std::io::Cursor;
+
+use bgpkit_commons::delegated::parse_reader;
+
+#[test]
+fn parser_preserves_source_records_without_asinfo_policy() {
+    let input = "\
+ripencc|GB|asn|219157|1|20260722|allocated
+arin|US|asn|300000|1|20200101|reserved
+ripencc|NL|ipv4|185.0.0.0|65536|20000101|allocated
+";
+
+    let records = parse_reader(Cursor::new(input))
+        .collect::<Result<Vec<_>, _>>()
+        .unwrap();
+
+    assert_eq!(records.len(), 3);
+    assert_eq!(records[0].registry, "ripencc");
+    assert_eq!(records[0].country, "GB");
+    assert_eq!(records[0].record_type, "asn");
+    assert_eq!(records[0].start, "219157");
+    assert_eq!(records[0].value, "1");
+    assert_eq!(records[0].status, "allocated");
+    assert_eq!(records[1].status, "reserved");
+    assert_eq!(records[2].record_type, "ipv4");
+}
+
+#[test]
+fn parser_reports_malformed_records() {
+    let input = "ripencc|GB|asn\n";
+    let mut records = parse_reader(Cursor::new(input));
+
+    assert!(records.next().unwrap().is_err());
+}

--- a/tests/irr_integration.rs
+++ b/tests/irr_integration.rs
@@ -1,0 +1,307 @@
+//! Integration tests for the IRR module using live IRR dump sources.
+//!
+//! These tests download real RPSL data from IRR registries and verify
+//! that the parser correctly extracts typed objects for well-known ASNs.
+
+#![cfg(feature = "irr")]
+
+use std::collections::HashMap;
+
+use bgpkit_commons::irr;
+use bgpkit_commons::irr::sources::{DumpFormat, Transport, default_sources};
+use bgpkit_commons::irr::types::{IrrObject, IrrObjectType};
+
+/// Parse RIPE aut-num split file and verify known ASNs are present.
+#[test]
+#[ignore = "network: downloads ~8MB from RIPE"]
+fn test_ripe_autnum_cloudflare_and_google() {
+    let source = default_sources()
+        .into_iter()
+        .find(|s| s.name == "RIPE")
+        .expect("RIPE source should be in defaults");
+
+    let dump_urls = source.dump_urls(IrrObjectType::AutNum);
+    assert_eq!(dump_urls.len(), 1);
+
+    let mut by_asn: HashMap<u32, irr::AutNum> = HashMap::new();
+    let stats = irr::parse_dump(&dump_urls[0], |obj| {
+        if let IrrObject::AutNum(a) = obj {
+            by_asn.insert(a.asn, a);
+        }
+    })
+    .unwrap();
+
+    // Should parse tens of thousands of objects
+    assert!(
+        stats.extracted > 10_000,
+        "expected >10k objects, got {}",
+        stats.extracted
+    );
+
+    // AS13335 = Cloudflare (registered in RIPE region via European entity)
+    if let Some(cf) = by_asn.get(&13335) {
+        assert!(
+            cf.as_name.contains("CLOUDFLARE") || cf.as_name.contains("Cloudflare"),
+            "AS13335 as_name should contain CLOUDFLARE, got: {}",
+            cf.as_name
+        );
+        assert_eq!(cf.source, "RIPE");
+    }
+
+    // AS15169 = Google
+    if let Some(google) = by_asn.get(&15169) {
+        assert!(
+            google.as_name.contains("GOOGLE"),
+            "AS15169 as_name should contain GOOGLE, got: {}",
+            google.as_name
+        );
+    }
+
+    // AS1299 = Arelion/Telia (large European transit, definitely in RIPE)
+    assert!(
+        by_asn.contains_key(&1299),
+        "AS1299 (Arelion) should be present in RIPE aut-num dump"
+    );
+}
+
+/// Parse RIPE route split file and verify known prefixes.
+#[test]
+#[ignore = "network: downloads ~12MB from RIPE"]
+fn test_ripe_route_objects() {
+    let source = default_sources()
+        .into_iter()
+        .find(|s| s.name == "RIPE")
+        .expect("RIPE source should be in defaults");
+
+    let dump_urls = source.dump_urls(IrrObjectType::Route);
+    assert_eq!(dump_urls.len(), 1);
+
+    let mut route_count = 0usize;
+    let mut saw_origin_13335 = false;
+
+    let stats = irr::parse_dump(&dump_urls[0], |obj| {
+        if let IrrObject::Route(r) = obj {
+            route_count += 1;
+            if r.origin == 13335 {
+                saw_origin_13335 = true;
+            }
+        }
+    })
+    .unwrap();
+
+    assert!(
+        stats.extracted > 100_000,
+        "expected >100k route objects from RIPE, got {}",
+        stats.extracted
+    );
+    // Cloudflare has route objects in RIPE
+    assert!(
+        saw_origin_13335,
+        "expected to find at least one route with origin AS13335"
+    );
+}
+
+/// Parse RADB via FTP and verify it works.
+/// RADB is the largest third-party IRR and is FTP-only.
+#[test]
+#[ignore = "network: downloads ~25MB via FTP from RADB"]
+fn test_radb_ftp_route_objects() {
+    let source = default_sources()
+        .into_iter()
+        .find(|s| s.name == "RADB")
+        .expect("RADB should be in defaults");
+
+    assert_eq!(source.transport, Transport::Ftp);
+
+    let dump_urls = source.dump_urls(IrrObjectType::Route);
+    assert_eq!(dump_urls.len(), 1);
+    assert_eq!(dump_urls[0].transport, Transport::Ftp);
+
+    let mut route_count = 0usize;
+    let mut saw_cloudflare = false;
+
+    let stats = irr::parse_dump(&dump_urls[0], |obj| {
+        if let IrrObject::Route(r) = obj {
+            route_count += 1;
+            if r.origin == 13335 && r.prefix.to_string().starts_with("1.1.1") {
+                saw_cloudflare = true;
+            }
+        }
+    })
+    .unwrap();
+
+    // RADB has over 1 million route objects
+    assert!(
+        stats.extracted > 500_000,
+        "expected >500k route objects from RADB, got {}",
+        stats.extracted
+    );
+    // 1.1.1.0/24 via AS13335 is a well-known RADB entry
+    assert!(
+        saw_cloudflare,
+        "expected to find 1.1.1.0/24 origin AS13335 in RADB"
+    );
+}
+
+/// Parse ARIN whole-DB and verify aut-num objects.
+/// ARIN's IRR is opt-in only, so coverage is sparser.
+#[test]
+#[ignore = "network: downloads ~5MB from ARIN"]
+fn test_arin_whole_db_autnum() {
+    let source = default_sources()
+        .into_iter()
+        .find(|s| s.name == "ARIN")
+        .expect("ARIN should be in defaults");
+
+    assert_eq!(source.format, DumpFormat::WholeDb);
+
+    let dump_urls = source.dump_urls(IrrObjectType::AutNum);
+    assert_eq!(dump_urls.len(), 1);
+    // Whole-DB URL is used for all object types
+    assert_eq!(
+        source.dump_urls(IrrObjectType::Route)[0].url,
+        dump_urls[0].url
+    );
+
+    let mut autnum_count = 0usize;
+    let mut other_count = 0usize;
+
+    irr::parse_dump(&dump_urls[0], |obj| match obj {
+        IrrObject::AutNum(_) => autnum_count += 1,
+        _ => other_count += 1,
+    })
+    .unwrap();
+
+    // ARIN has ~4k aut-num objects
+    assert!(
+        autnum_count > 1_000,
+        "expected >1k aut-num objects from ARIN, got {}",
+        autnum_count
+    );
+    // Whole-DB should also yield route objects
+    assert!(
+        other_count > 10_000,
+        "expected >10k other objects (routes etc.) from ARIN whole-DB, got {}",
+        other_count
+    );
+}
+
+/// Verify that APNIC split files work correctly.
+#[test]
+#[ignore = "network: downloads ~2MB from APNIC"]
+fn test_apnic_autnum() {
+    let source = default_sources()
+        .into_iter()
+        .find(|s| s.name == "APNIC")
+        .expect("APNIC should be in defaults");
+
+    let dump_urls = source.dump_urls(IrrObjectType::AutNum);
+    assert_eq!(dump_urls.len(), 1);
+    assert_eq!(dump_urls[0].transport, Transport::Https);
+
+    let mut autnum_count = 0usize;
+
+    let _stats = irr::parse_dump(&dump_urls[0], |obj| {
+        if let IrrObject::AutNum(a) = obj {
+            autnum_count += 1;
+            assert_eq!(a.source, "APNIC");
+        }
+    })
+    .unwrap();
+
+    assert!(
+        autnum_count > 1_000,
+        "expected >1k aut-num from APNIC, got {}",
+        autnum_count
+    );
+}
+
+/// Verify source registry covers all default sources.
+#[test]
+fn test_default_sources_coverage() {
+    let sources = default_sources();
+    let names: Vec<&str> = sources.iter().map(|s| s.name).collect();
+
+    // Must include the 5 RIRs + RADB + NTTCOM
+    for required in &[
+        "RIPE", "APNIC", "ARIN", "LACNIC", "AFRINIC", "RADB", "NTTCOM",
+    ] {
+        assert!(
+            names.contains(required),
+            "default sources should include {required}"
+        );
+    }
+}
+
+/// Verify all default sources have URLs for each supported object type.
+#[test]
+fn test_default_sources_have_urls() {
+    for source in default_sources() {
+        for obj_type in IrrObjectType::all() {
+            let urls = source.dump_urls(*obj_type);
+            assert!(
+                !urls.is_empty(),
+                "source {} should have a URL for {:?}",
+                source.name,
+                obj_type
+            );
+        }
+    }
+}
+
+/// Verify IrrDumpUrl URLs point to the right transports.
+#[test]
+fn test_transport_correctness() {
+    for source in default_sources() {
+        let urls = source.dump_urls(IrrObjectType::AutNum);
+        for url in &urls {
+            assert_eq!(
+                url.transport, source.transport,
+                "source {} URL transport mismatch",
+                source.name
+            );
+            if url.transport == Transport::Ftp {
+                assert!(
+                    url.url.starts_with("ftp://"),
+                    "FTP source {} URL should start with ftp://",
+                    source.name
+                );
+            } else {
+                assert!(
+                    url.url.starts_with("https://"),
+                    "HTTPS source {} URL should start with https://",
+                    source.name
+                );
+            }
+        }
+    }
+}
+
+/// Verify all_sources() includes more registries than default_sources().
+#[test]
+fn test_all_sources_superset() {
+    let all = irr::all_sources();
+    let defaults = default_sources();
+
+    assert!(
+        all.len() > defaults.len(),
+        "all_sources should have more entries than defaults"
+    );
+
+    for default_src in &defaults {
+        assert!(
+            all.iter().any(|s| s.name == default_src.name),
+            "default source {} should also be in all_sources",
+            default_src.name
+        );
+    }
+
+    // all_sources should include regional registries not in defaults
+    let all_names: Vec<&str> = all.iter().map(|s| s.name).collect();
+    for expected in &["ALTDB", "BELL", "BBOI", "JPIRR", "TC", "CANARIE", "REACH"] {
+        assert!(
+            all_names.contains(expected),
+            "all_sources should include {expected}"
+        );
+    }
+}

--- a/tests/irr_source_records.rs
+++ b/tests/irr_source_records.rs
@@ -1,0 +1,68 @@
+#![cfg(feature = "irr")]
+
+use std::io::Cursor;
+
+use bgpkit_commons::irr::{IrrObject, all_sources, parse_reader, sources_by_name};
+
+#[test]
+fn raw_parser_preserves_unsupported_objects_and_attribute_order() {
+    let input = "\
+person:         Jane Doe
+remarks:        first
+remarks:        second
+                continued
+source:         TEST
+";
+
+    let records = parse_reader(Cursor::new(input))
+        .collect::<Result<Vec<_>, _>>()
+        .unwrap();
+
+    assert_eq!(records.len(), 1);
+    let record = &records[0];
+    assert_eq!(record.object_type, "person");
+    assert_eq!(record.attributes.len(), 4);
+    assert_eq!(record.attributes[1].name, "remarks");
+    assert_eq!(record.attributes[1].value, "first");
+    assert_eq!(record.attributes[2].name, "remarks");
+    assert_eq!(record.attributes[2].value, "second\ncontinued");
+    assert_eq!(record.attributes[3].name, "source");
+}
+
+#[test]
+fn raw_parser_returns_malformed_objects_as_errors() {
+    let input = "aut-num: AS13335\nthis is not an attribute\n";
+    let mut records = parse_reader(Cursor::new(input));
+
+    assert!(records.next().unwrap().is_err());
+}
+
+#[test]
+fn supported_raw_record_converts_to_existing_typed_object() {
+    let input = "aut-num: AS13335\nas-name: CLOUDFLARENET\nsource: RIPE\n";
+    let record = parse_reader(Cursor::new(input)).next().unwrap().unwrap();
+
+    match record.to_typed().unwrap() {
+        Some(IrrObject::AutNum(aut_num)) => {
+            assert_eq!(aut_num.asn, 13335);
+            assert_eq!(aut_num.as_name, "CLOUDFLARENET");
+            assert_eq!(aut_num.source, "RIPE");
+        }
+        other => panic!("expected typed aut-num, got {other:?}"),
+    }
+}
+
+#[test]
+fn explicit_source_selection_is_validated_and_deduplicated() {
+    let selected = sources_by_name(&["RIPE", "RADB", "RIPE"]).unwrap();
+    assert_eq!(
+        selected
+            .iter()
+            .map(|source| source.name)
+            .collect::<Vec<_>>(),
+        vec!["RIPE", "RADB"]
+    );
+
+    assert!(sources_by_name(&["RIPE", "NOT-A-REGISTRY"]).is_err());
+    assert!(all_sources().len() > selected.len());
+}

--- a/tests/irr_source_records.rs
+++ b/tests/irr_source_records.rs
@@ -2,7 +2,10 @@
 
 use std::io::Cursor;
 
-use bgpkit_commons::irr::{IrrObject, all_sources, parse_reader, sources_by_name};
+use bgpkit_commons::irr::{
+    DumpFormat, IrrObject, IrrObjectType, IrrSource, Transport, all_sources, fetch, parse_reader,
+    sources_by_name,
+};
 
 #[test]
 fn raw_parser_preserves_unsupported_objects_and_attribute_order() {
@@ -14,9 +17,9 @@ remarks:        second
 source:         TEST
 ";
 
-    let records = parse_reader(Cursor::new(input))
-        .collect::<Result<Vec<_>, _>>()
-        .unwrap();
+    let records = parse_reader(Cursor::new(input), DumpFormat::WholeDb);
+    assert_eq!(records.format(), DumpFormat::WholeDb);
+    let records = records.collect::<Result<Vec<_>, _>>().unwrap();
 
     assert_eq!(records.len(), 1);
     let record = &records[0];
@@ -32,7 +35,7 @@ source:         TEST
 #[test]
 fn raw_parser_returns_malformed_objects_as_errors() {
     let input = "aut-num: AS13335\nthis is not an attribute\n";
-    let mut records = parse_reader(Cursor::new(input));
+    let mut records = parse_reader(Cursor::new(input), DumpFormat::WholeDb);
 
     assert!(records.next().unwrap().is_err());
 }
@@ -40,7 +43,10 @@ fn raw_parser_returns_malformed_objects_as_errors() {
 #[test]
 fn supported_raw_record_converts_to_existing_typed_object() {
     let input = "aut-num: AS13335\nas-name: CLOUDFLARENET\nsource: RIPE\n";
-    let record = parse_reader(Cursor::new(input)).next().unwrap().unwrap();
+    let record = parse_reader(Cursor::new(input), DumpFormat::SplitFiles)
+        .next()
+        .unwrap()
+        .unwrap();
 
     match record.to_typed().unwrap() {
         Some(IrrObject::AutNum(aut_num)) => {
@@ -65,4 +71,17 @@ fn explicit_source_selection_is_validated_and_deduplicated() {
 
     assert!(sources_by_name(&["RIPE", "NOT-A-REGISTRY"]).is_err());
     assert!(all_sources().len() > selected.len());
+}
+
+#[test]
+fn fetch_rejects_a_source_outside_the_catalog_before_network_io() {
+    let unknown = IrrSource {
+        name: "NOT-A-REGISTRY",
+        display_name: "Unknown",
+        authoritative: false,
+        transport: Transport::Https,
+        format: DumpFormat::WholeDb,
+    };
+
+    assert!(fetch(&unknown, IrrObjectType::AutNum).is_err());
 }


### PR DESCRIPTION
## Summary

Add IRR (Internet Routing Registry) data support to bgpkit-commons, including a new `irr` module for parsing RPSL data and extending `asinfo` with structured IRR and delegated-stats enrichment.

### New `irr` module
Library-level RPSL parsing toolkit using [rpsl-rs](https://crates.io/crates/rpsl-rs) v3.0:
- **14 known IRR registries** (RIPE, APNIC, ARIN, LACNIC, AFRINIC, NTTCOM, RADB, + 7 more) with per-registry dump URLs, transport (HTTPS/FTP), and format (split files vs whole-DB)
- **Typed structs** for 7 RPSL object types: `AutNum`, `Route`, `Route6`, `AsSet`, `RouteSet`, `Mntner`, `Organisation`
- **Streaming parser** via oneio with lossy UTF-8 handling for legacy IRR data
- **Single-pass download** for whole-DB sources (RADB, ARIN, etc. downloaded once, all object types extracted)

### Extended `asinfo` module
- **`DelegatedInfo`** struct: structured RIR delegated-stats data (registry, country, date, status) for every allocated ASN
- **`IrrAsnInfo`** struct: per-source IRR data (as-name, descr, mnt-by, route prefixes, route6 prefixes, as-set memberships) stored as a `Vec` so callers pick which source(s) to trust
- **`AsInfoProfile`** enum with three presets:
  - `Minimum`: asn.txt only (~1s load)
  - `Default`: + as2org, population, hegemony, peeringdb (~30s) — matches current production
  - `Full`: + delegated stats + IRR data with route prefixes (~75s)
- **`AsInfoBuilder`** for fine-grained control: `.with_irr_sources()`, `.with_irr_route_prefixes()`, etc.
- **Route prefix collection is opt-in** — off by default, saving ~90MB in serialized output
- **Unknown ASN names filled** from IRR aut-num as-name (363 remaining UNKNOWN out of ~999 gap ASNs)

### Breaking changes
- `load_asinfo(bool, bool, bool, bool)` → `load_asinfo_with_profile(AsInfoProfile)`
- `AsInfo` gains `delegated: Option<DelegatedInfo>` and `irr: Vec<IrrAsnInfo>` fields
- `asinfo` feature now depends on `irr` feature

## Performance (live data, release build)

| Source | Time |
|--------|------|
| asn.txt only | ~1s |
| Delegated stats (5 RIRs) | ~12s |
| IRR RIPE (4 split files) | ~7s |
| IRR AFRINIC (whole-DB) | ~18s (slowest) |
| IRR RADB (FTP, 25MB) | ~10s |
| All IRR combined | ~43s |
| Full profile | ~73s |

## Output sizes

| Profile | Raw JSONL | Gzipped |
|---------|-----------|---------|
| Production (current) | 37 MB | 6.3 MB |
| Full, no routes | 160 MB | 24 MB |
| Full, with routes | 203 MB | 31 MB |

## Test plan
- [x] 48 lib unit tests pass (including 6 delegated-stats parser tests, 4 IRR streaming tests)
- [x] 4 non-network integration tests pass (source registry coverage, URL correctness, transport verification)
- [x] Live network tests verified: RIPE aut-num (AS13335=Cloudflare, AS15169=Google, AS1299=Arelion), RIPE routes, RADB FTP routes (1.1.1.0/24 via AS13335), ARIN whole-DB, APNIC
- [x] `cargo fmt --check` clean
- [x] `cargo clippy --all-features -- -D warnings` clean
- [x] `cargo build --no-default-features` and `--features irr` both compile

Closes #38
