### PR TITLE
fix(asinfo): complete next-gen serde round-trip and serving-layer tests

### DIFF
--- a/NEXTGEN_INTERFACE_SPEC.md
+++ b/NEXTGEN_INTERFACE_SPEC.md
@@ -61,10 +61,11 @@ The canonical parser accepts a reader and yields source records:
 pub fn parse_reader<R: Read>(
     reader: R,
     format: DumpFormat,
-) -> impl Iterator<Item = Result<IrrRecord, IrrError>>;
+) -> impl Iterator<Item = Result<IrrRecord>>;
 ```
 
-`IrrRecord` represents one RPSL object without AsInfo policy:
+Errors use the crate-wide `BgpkitCommonsError`/`Result` types. `IrrRecord`
+represents one RPSL object without AsInfo policy:
 
 ```rust
 pub struct IrrRecord {
@@ -137,7 +138,7 @@ Source selection changes which registries are fetched; it does not establish a p
 PR #39 currently fetches and parses RIR delegated-statistics files inside `asinfo`. Move that work into a small `delegated` source module so it can be used without AsInfo.
 
 ```rust
-pub fn parse_reader<R: Read>(reader: R) -> impl Iterator<Item = Result<DelegatedRecord, DelegatedError>>;
+pub fn parse_reader<R: Read>(reader: R) -> impl Iterator<Item = Result<DelegatedRecord>>;
 
 pub struct DelegatedRecord {
     pub registry: String,
@@ -147,10 +148,16 @@ pub struct DelegatedRecord {
     pub value: String,
     pub date: String,
     pub status: String,
+    pub extensions: Vec<String>,
 }
 ```
 
-The source parser returns delegated records as published. It does not fill missing ASNs, replace names or countries, or decide which statuses belong in AsInfo. Fetching the five RIR files is also exposed by the `delegated` module.
+Errors use the crate-wide `BgpkitCommonsError`/`Result` types (there is no
+module-specific error type). The `extensions` field carries any extra
+pipe-delimited fields beyond the standard seven (the NRO extended format).
+The source parser returns delegated records as published. It does not fill
+missing ASNs, replace names or countries, or decide which statuses belong in
+AsInfo. Fetching the five RIR files is also exposed by the `delegated` module.
 
 Filtering to ASN allocation records and constructing `DelegatedInfo` happens in the AsInfo serving layer.
 
@@ -179,7 +186,12 @@ pub struct AsInfo {
 }
 ```
 
-Serde defaults are required so existing cached JSON without `delegated` or `irr` remains readable. This fixes the current PR #39 failure: `missing field 'irr'`.
+Serde defaults are required so existing cached JSON without `delegated` or `irr`
+remains readable. This fixes the current PR #39 failure: `missing field 'irr'`.
+All optional enrichment fields (`as2org`, `population`, `hegemony`, `peeringdb`,
+`delegated`) carry `#[serde(default, skip_serializing_if = "Option::is_none")]`
+so that newly-serialized records — which omit absent fields — round-trip
+through `AsInfo::deserialize` without `missing field` errors.
 
 Serialization includes only data that exists for that ASN:
 
@@ -220,7 +232,13 @@ pub struct DelegatedInfo {
 
 There may be multiple entries for an ASN because different IRR registries can publish different values. The library does not choose a trusted IRR registry or overwrite the existing `name`, `country`, or other source fields with IRR values.
 
-Delegated data is likewise retained in `delegated`; it does not overwrite the base `name` or `country` fields.
+Delegated data is likewise retained in `delegated`; it does not overwrite the
+base `name` or `country` fields. For ASNs absent from `asn.txt` (newly
+allocated, covered by delegated stats but lagging in `asn.txt`), the serving
+layer creates an entry with `name: "UNKNOWN"` and the delegated country as the
+base `country`. When the same ASN appears in more than one RIR delegated file
+(possible during inter-RIR transfers), the first record wins; file order is
+the fixed order of `RIR_DELEGATED_STATS_URLS`.
 
 ## 6. AsInfo profiles
 

--- a/src/asinfo/mod.rs
+++ b/src/asinfo/mod.rs
@@ -152,13 +152,15 @@ pub struct AsInfo {
     pub asn: u32,
     pub name: String,
     pub country: String,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    /// Serde defaults on every optional field keep newly-serialized records
+    /// (which omit absent fields) readable by the same struct on deserialization.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub as2org: Option<As2orgInfo>,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub population: Option<AsnPopulationData>,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub hegemony: Option<HegemonyData>,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub peeringdb: Option<Network>,
     /// RIR delegated-stats allocation data. Present for every allocated ASN.
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -688,9 +690,33 @@ fn fill_delegated_data(
             Err(e) => warn!("failed to load delegated stats from {}: {}", url, e),
         }
     }
+    attach_delegated_data(
+        asnames_map,
+        delegated,
+        as2org_utils,
+        population_utils,
+        hegemony_utils,
+        peeringdb_utils,
+    );
+}
 
-    // Attach delegated data to existing entries, and create new entries for
-    // ASNs missing from asn.txt.
+/// Attach per-ASN [`DelegatedInfo`] values to the map, creating `AsInfo`
+/// entries for ASNs absent from `asn.txt` (with `name: "UNKNOWN"` and the
+/// delegated country as the base country).
+///
+/// Only the `delegated` field of existing entries is modified; the base `name`
+/// and `country` fields are never overwritten. When the same ASN appears in
+/// multiple RIR files (possible during inter-RIR transfers), the first
+/// [`DelegatedInfo`] encountered wins; file order is the order of
+/// [`crate::delegated::RIR_DELEGATED_STATS_URLS`].
+fn attach_delegated_data(
+    asnames_map: &mut HashMap<u32, AsInfo>,
+    delegated: HashMap<u32, DelegatedInfo>,
+    as2org_utils: Option<&as2org::As2org>,
+    population_utils: Option<&population::AsnPopulation>,
+    hegemony_utils: Option<&hegemony::Hegemony>,
+    peeringdb_utils: Option<&Peeringdb>,
+) {
     let mut new_entries = 0usize;
     let mut attached = 0usize;
     for (asn, delegated_info) in delegated {
@@ -844,7 +870,7 @@ fn enrich_from_irr(
                             for &member_asn in &s.members {
                                 let entry = source_map.entry(member_asn).or_default();
                                 if entry.source.is_empty() {
-                                    entry.source = sn.clone();
+                                    entry.source = s.source.clone();
                                 }
                                 entry.member_of_sets.push(set_name.clone());
                             }
@@ -862,7 +888,22 @@ fn enrich_from_irr(
         }
     }
 
-    // Attach per-source IrrAsnInfo to each ASN
+    attach_irr_data(asnames_map, per_source, irr_sources);
+}
+
+/// Attach per-source [`IrrAsnInfo`] values to each ASN.
+///
+/// Only the `irr` field of existing entries is modified; the base `name` and
+/// `country` fields are never overwritten. Entries are produced in the order
+/// of `irr_sources`, one per registry that has any data for the ASN.
+fn attach_irr_data(
+    asnames_map: &mut HashMap<u32, AsInfo>,
+    per_source: std::collections::HashMap<
+        String,
+        std::collections::HashMap<u32, IrrAsnInfoBuilder>,
+    >,
+    irr_sources: &[crate::irr::IrrSource],
+) {
     let mut irr_attached = 0usize;
 
     for (asn, info) in asnames_map.iter_mut() {
@@ -1360,5 +1401,102 @@ ripencc|GB|asn|100|1|20200101|allocated|extra|fields|ok
                 .collect::<Vec<_>>(),
             vec!["RIPE", "RADB"]
         );
+    }
+
+    #[test]
+    fn delegated_enrichment_never_overwrites_name_or_country() {
+        let mut map = HashMap::new();
+        map.insert(
+            13335,
+            AsInfo {
+                asn: 13335,
+                name: "CLOUDFLARENET".to_string(),
+                country: "US".to_string(),
+                as2org: None,
+                population: None,
+                hegemony: None,
+                peeringdb: None,
+                delegated: None,
+                irr: Vec::new(),
+            },
+        );
+
+        let mut delegated = HashMap::new();
+        delegated.insert(
+            13335,
+            DelegatedInfo {
+                registry: "ripencc".to_string(),
+                country: "GB".to_string(),
+                date: "20260722".to_string(),
+                status: "allocated".to_string(),
+            },
+        );
+        // ASN missing from asn.txt: a new entry is created, not an overwrite.
+        delegated.insert(
+            400644,
+            DelegatedInfo {
+                registry: "arin".to_string(),
+                country: "US".to_string(),
+                date: "20200101".to_string(),
+                status: "allocated".to_string(),
+            },
+        );
+
+        attach_delegated_data(&mut map, delegated, None, None, None, None);
+
+        // Existing entry: base fields untouched, delegated attached.
+        let existing = &map[&13335];
+        assert_eq!(existing.name, "CLOUDFLARENET");
+        assert_eq!(existing.country, "US");
+        assert_eq!(existing.delegated.as_ref().unwrap().registry, "ripencc");
+
+        // New entry: UNKNOWN name, delegated country as base country.
+        let new_entry = &map[&400644];
+        assert_eq!(new_entry.name, "UNKNOWN");
+        assert_eq!(new_entry.country, "US");
+        assert_eq!(new_entry.delegated.as_ref().unwrap().registry, "arin");
+    }
+
+    #[test]
+    fn irr_enrichment_never_overwrites_name_or_country() {
+        let mut map = HashMap::new();
+        map.insert(
+            13335,
+            AsInfo {
+                asn: 13335,
+                name: "CLOUDFLARENET".to_string(),
+                country: "US".to_string(),
+                as2org: None,
+                population: None,
+                hegemony: None,
+                peeringdb: None,
+                delegated: None,
+                irr: Vec::new(),
+            },
+        );
+
+        // A single source with data for AS13335 (as_name disagrees with the
+        // base name on purpose: IRR must not replace the base fields).
+        let mut per_source: std::collections::HashMap<
+            String,
+            std::collections::HashMap<u32, IrrAsnInfoBuilder>,
+        > = std::collections::HashMap::new();
+        let mut builder = IrrAsnInfoBuilder::default();
+        builder.source = "RIPE".to_string();
+        builder.as_name = "CLOUDFLARE-NET".to_string();
+        per_source.insert("RIPE".to_string(), [(13335, builder)].into_iter().collect());
+
+        let ripe = crate::irr::sources::all_sources()
+            .into_iter()
+            .find(|source| source.name == "RIPE")
+            .unwrap();
+        attach_irr_data(&mut map, per_source, &[ripe]);
+
+        let info = &map[&13335];
+        assert_eq!(info.name, "CLOUDFLARENET");
+        assert_eq!(info.country, "US");
+        assert_eq!(info.irr.len(), 1);
+        assert_eq!(info.irr[0].as_name, "CLOUDFLARE-NET");
+        assert_eq!(info.irr[0].source, "RIPE");
     }
 }

--- a/tests/asinfo_integration.rs
+++ b/tests/asinfo_integration.rs
@@ -99,10 +99,24 @@ fn test_irr_and_delegated_enrichment() {
     let ripe_entry = cf.irr.iter().find(|i| i.source == "RIPE");
     assert!(ripe_entry.is_some(), "AS13335 should have RIPE IRR entry");
     let ripe = ripe_entry.unwrap();
+    // AS13335's RIPE aut-num is registered in the ripe-nonauth source, which
+    // is not part of the ripe split files the catalog fetches, so the RIPE
+    // entry is built from route objects and carries no as_name. Verify the
+    // route prefixes instead.
     assert!(
-        ripe.as_name.contains("CLOUDFLARE"),
-        "AS13335 RIPE as_name should contain CLOUDFLARE, got: {}",
-        ripe.as_name
+        !ripe.route_prefixes.is_empty(),
+        "AS13335 RIPE entry should have route prefixes from ripe.db.route"
+    );
+
+    // Aut-num enrichment is verified on AS3333, whose aut-num is in the ripe
+    // source with a stable as-name.
+    let ncc = commons.asinfo_get(3333).unwrap().unwrap();
+    let ncc_ripe = ncc.irr.iter().find(|i| i.source == "RIPE");
+    assert!(ncc_ripe.is_some(), "AS3333 should have RIPE IRR entry");
+    assert_eq!(
+        ncc_ripe.unwrap().as_name,
+        "RIPE-NCC-AS",
+        "AS3333 RIPE as_name should be RIPE-NCC-AS"
     );
 
     // === Route prefixes ===

--- a/tests/asinfo_serialization.rs
+++ b/tests/asinfo_serialization.rs
@@ -1,6 +1,6 @@
 #![cfg(feature = "asinfo")]
 
-use bgpkit_commons::asinfo::{AsInfo, IrrAsnInfo};
+use bgpkit_commons::asinfo::{AsInfo, DelegatedInfo, IrrAsnInfo};
 use ipnet::{Ipv4Net, Ipv6Net};
 use serde_json::{Value, json};
 
@@ -15,6 +15,93 @@ fn old_records_without_new_fields_still_deserialize() {
     let info: AsInfo = serde_json::from_value(value).unwrap();
     assert!(info.delegated.is_none());
     assert!(info.irr.is_empty());
+}
+
+#[test]
+fn old_records_with_null_enrichment_fields_still_deserialize() {
+    // Shape produced by the currently-deployed asninfo cronjob output:
+    // every optional enrichment key present, with null for missing data.
+    let value = json!({
+        "as2org": null,
+        "asn": 0,
+        "country": "ZZ",
+        "hegemony": null,
+        "name": "-Reserved AS-",
+        "peeringdb": null,
+        "population": null
+    });
+
+    let info: AsInfo = serde_json::from_value(value).unwrap();
+    assert_eq!(info.asn, 0);
+    assert_eq!(info.name, "-Reserved AS-");
+    assert!(info.as2org.is_none());
+    assert!(info.population.is_none());
+    assert!(info.hegemony.is_none());
+    assert!(info.peeringdb.is_none());
+    assert!(info.delegated.is_none());
+    assert!(info.irr.is_empty());
+}
+
+#[test]
+fn newly_serialized_records_round_trip_through_deserialization() {
+    // Serialization omits absent optional fields (including `as2org` etc.), so
+    // deserialization needs serde defaults on every optional field for the
+    // round trip to succeed.
+    let info = AsInfo {
+        asn: 13335,
+        name: "CLOUDFLARENET".to_string(),
+        country: "US".to_string(),
+        as2org: None,
+        population: None,
+        hegemony: None,
+        peeringdb: None,
+        delegated: None,
+        irr: Vec::new(),
+    };
+
+    let serialized = serde_json::to_string(&info).unwrap();
+    let deserialized: AsInfo = serde_json::from_str(&serialized).unwrap();
+    assert_eq!(
+        serde_json::to_value(&info).unwrap(),
+        serde_json::to_value(&deserialized).unwrap()
+    );
+
+    // Same round trip with every optional field present.
+    let full = AsInfo {
+        asn: 13335,
+        name: "CLOUDFLARENET".to_string(),
+        country: "US".to_string(),
+        as2org: Some(bgpkit_commons::asinfo::As2orgInfo {
+            name: "CLOUDFLARENET".to_string(),
+            country: "US".to_string(),
+            org_id: "CLOUDFLARE-INC".to_string(),
+            org_name: "Cloudflare, Inc.".to_string(),
+        }),
+        population: None,
+        hegemony: None,
+        peeringdb: None,
+        delegated: Some(DelegatedInfo {
+            registry: "arin".to_string(),
+            country: "US".to_string(),
+            date: "20100726".to_string(),
+            status: "allocated".to_string(),
+        }),
+        irr: vec![IrrAsnInfo {
+            as_name: "CLOUDFLARENET".to_string(),
+            descr: Vec::new(),
+            source: "RIPE".to_string(),
+            mnt_by: Vec::new(),
+            route_prefixes: Vec::new(),
+            route6_prefixes: Vec::new(),
+            member_of_sets: Vec::new(),
+        }],
+    };
+    let serialized = serde_json::to_string(&full).unwrap();
+    let deserialized: AsInfo = serde_json::from_str(&serialized).unwrap();
+    assert_eq!(
+        serde_json::to_value(&full).unwrap(),
+        serde_json::to_value(&deserialized).unwrap()
+    );
 }
 
 #[test]
@@ -44,6 +131,48 @@ fn absent_enrichments_are_omitted_from_serialization() {
             .collect()
         )
     );
+}
+
+#[test]
+fn present_enrichments_are_included_in_serialization() {
+    let info = AsInfo {
+        asn: 13335,
+        name: "CLOUDFLARENET".to_string(),
+        country: "US".to_string(),
+        as2org: Some(bgpkit_commons::asinfo::As2orgInfo {
+            name: "CLOUDFLARENET".to_string(),
+            country: "US".to_string(),
+            org_id: "CLOUDFLARE-INC".to_string(),
+            org_name: "Cloudflare, Inc.".to_string(),
+        }),
+        population: None,
+        hegemony: None,
+        peeringdb: None,
+        delegated: Some(DelegatedInfo {
+            registry: "arin".to_string(),
+            country: "US".to_string(),
+            date: "20100726".to_string(),
+            status: "allocated".to_string(),
+        }),
+        irr: vec![IrrAsnInfo {
+            as_name: "CLOUDFLARENET".to_string(),
+            descr: Vec::new(),
+            source: "RIPE".to_string(),
+            mnt_by: Vec::new(),
+            route_prefixes: Vec::new(),
+            route6_prefixes: Vec::new(),
+            member_of_sets: Vec::new(),
+        }],
+    };
+
+    let value = serde_json::to_value(&info).unwrap();
+    assert_eq!(value["as2org"]["org_id"], json!("CLOUDFLARE-INC"));
+    assert_eq!(value["delegated"]["registry"], json!("arin"));
+    assert_eq!(value["irr"][0]["source"], json!("RIPE"));
+    // absent fields stay omitted even when siblings are present
+    assert!(value.get("population").is_none());
+    assert!(value.get("hegemony").is_none());
+    assert!(value.get("peeringdb").is_none());
 }
 
 #[test]


### PR DESCRIPTION
## Summary

Finishes the next-gen interface work from `NEXTGEN_INTERFACE_SPEC.md` on top of the merged PR #39 (`feat/irr-data-support`), plus the library-side changes needed to keep the downstream `asninfo` default output field-level non-breaking.

## Changes

### Serialization round-trip fix (`src/asinfo/mod.rs`)
- Added `#[serde(default, skip_serializing_if = "Option::is_none")]` to `AsInfo.as2org`/`population`/`hegemony`/`peeringdb` (previously only `delegated`/`irr` had defaults).
- Before this change, records serialized under the new skip-absent-fields rule could not be deserialized back into `AsInfo` (`missing field 'as2org'`), so a newly generated `Minimum`-profile cache would not load via `load_asinfo_cached()`. Old JSON (with `null`s) and new JSON (omitted fields) now both round-trip.

### Serving-layer refactor for testability
- Split `fill_delegated_data` → fetch + `attach_delegated_data`, and `enrich_from_irr` → fetch + `attach_irr_data`, so the "delegated/IRR never overwrite `name`/`country`" invariant is testable without network access (spec §9 item 17).
- Documented the serving-layer policies that were previously implicit: `name: "UNKNOWN"` synthetic entries for ASNs absent from `asn.txt`, and first-record-wins for ASNs appearing in multiple RIR delegated files.
- As-set-only `IrrAsnInfo.source` now uses the object's RPSL `source:` attribute instead of the fetched registry name, matching the spec.

### Tests
- `tests/asinfo_serialization.rs`: deployed-format-with-`null`s deserialization, serialize→deserialize round trip, present-enrichments inclusion, typed-prefix CIDR serialization.
- `src/asinfo/mod.rs`: deterministic `delegated_enrichment_never_overwrites_name_or_country` and `irr_enrichment_never_overwrites_name_or_country`.
- `tests/asinfo_integration.rs`: fixed a stale network-test assertion — AS13335's RIPE aut-num lives in the `ripe-nonauth` source (not fetched by the catalog), so the RIPE entry carries no `as_name`; anchored the aut-num enrichment check on AS3333 (`RIPE-NCC-AS`).

### Docs
- `NEXTGEN_INTERFACE_SPEC.md`: aligned with the implementation (`DelegatedRecord.extensions`, crate-wide error types, round-trip serde note, delegated serving policies).

## Verification

- `cargo test --all-features` (52 lib + integration + 31 doctests), `cargo clippy --all-features -- -D warnings`, `cargo fmt --check`, `cargo build --no-default-features` all pass.
- Ignored network tests re-run and passing: `test_irr_and_delegated_enrichment` (Full profile end-to-end, ~80 MB downloads) and all five `tests/irr_integration.rs` network tests.
- Downstream compatibility: the existing unmodified `asninfo` binary, built against this branch, regenerated the default output and was compared against the currently deployed file (`spaces.bgpkit.org/broker/asninfo.jsonl`, 121,463 records):
  - 100% of deployed records deserialize into the new `AsInfo` (backward compatible).
  - Default-profile output contains no `irr`/`delegated` fields (no leaks).
  - `as2org` identical across both files (0 diffs); remaining diffs in `name`/`country`/`population`/`hegemony`/`peeringdb` are daily data-source drift.
  - PeeringDB nested object is a strict additive superset: the legacy `aka`/`asn`/`irr_as_set`/`name`/`name_long`/`website` keys are preserved with identical types and values (modulo live data updates).
