### PR TITLE
feat(export): add all_entries() iteration accessors

### DIFF
--- a/src/as2rel/mod.rs
+++ b/src/as2rel/mod.rs
@@ -181,6 +181,56 @@ impl As2relBgpkit {
 
         (v4_entries, v6_entries)
     }
+
+    /// Iterate over all unique relationship entries.
+    ///
+    /// Each (asn1, asn2) pair appears once in canonical order (asn1 < asn2).
+    /// Returns both IPv4 and IPv6 entries, tagged by address family.
+    #[allow(dead_code)]
+    pub fn all_entries(&self) -> impl Iterator<Item = As2relExportEntry> + '_ {
+        let v4 = self
+            .v4_rels_map
+            .iter()
+            .filter(move |((a, b), _)| *a < *b)
+            .flat_map(|(_, set)| {
+                set.iter().map(move |e| As2relExportEntry {
+                    asn1: e.asn1,
+                    asn2: e.asn2,
+                    rel: e.rel,
+                    paths_count: e.paths_count,
+                    peers_count: e.peers_count,
+                    address_family: 4,
+                })
+            })
+            .collect::<Vec<_>>();
+        let v6 = self
+            .v6_rels_map
+            .iter()
+            .filter(move |((a, b), _)| *a < *b)
+            .flat_map(|(_, set)| {
+                set.iter().map(move |e| As2relExportEntry {
+                    asn1: e.asn1,
+                    asn2: e.asn2,
+                    rel: e.rel,
+                    paths_count: e.paths_count,
+                    peers_count: e.peers_count,
+                    address_family: 6,
+                })
+            })
+            .collect::<Vec<_>>();
+        v4.into_iter().chain(v6)
+    }
+}
+
+/// A single AS relationship entry for export, with address family tag.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct As2relExportEntry {
+    pub asn1: u32,
+    pub asn2: u32,
+    pub rel: AsRelationship,
+    pub paths_count: u32,
+    pub peers_count: u32,
+    pub address_family: u8,
 }
 
 impl LazyLoadable for As2relBgpkit {

--- a/src/asinfo/as2org.rs
+++ b/src/asinfo/as2org.rs
@@ -180,6 +180,12 @@ impl As2org {
         )
     }
 
+    /// Iterate over all AS entries in arbitrary order.
+    #[allow(dead_code)]
+    pub fn all_as_info(&self) -> impl Iterator<Item = As2orgAsInfo> + '_ {
+        self.as_map.keys().filter_map(|&asn| self.get_as_info(asn))
+    }
+
     /// Return `true` if both ASNs belong to the same organization.
     #[allow(dead_code)]
     pub fn are_siblings(&self, asn1: u32, asn2: u32) -> bool {

--- a/src/asinfo/hegemony.rs
+++ b/src/asinfo/hegemony.rs
@@ -86,4 +86,10 @@ impl Hegemony {
     pub fn get_score(&self, asn: u32) -> Option<&HegemonyData> {
         self.hegemony_map.get(&asn)
     }
+
+    /// Iterate over all hegemony entries in arbitrary order.
+    #[allow(dead_code)]
+    pub fn all_scores(&self) -> impl Iterator<Item = &HegemonyData> {
+        self.hegemony_map.values()
+    }
 }

--- a/src/asinfo/population.rs
+++ b/src/asinfo/population.rs
@@ -75,4 +75,10 @@ impl AsnPopulation {
                 sample_count: entry.sample_count,
             })
     }
+
+    /// Iterate over all population entries in arbitrary order.
+    #[allow(dead_code)]
+    pub fn all_entries(&self) -> impl Iterator<Item = &ApnicAsnPopulationEntry> {
+        self.population_map.values()
+    }
 }


### PR DESCRIPTION
## Summary

Add iteration accessors to four modules with private internal maps, enabling future Parquet export of their full datasets.

- `as2org`: `As2org::all_as_info()` -> `Iterator<As2orgAsInfo>`
- `hegemony`: `Hegemony::all_scores()` -> `Iterator<&HegemonyData>`
- `population`: `AsnPopulation::all_entries()` -> `Iterator<&ApnicAsnPopulationEntry>`
- `as2rel`: `As2relBgpkit::all_entries()` -> `Iterator<As2relExportEntry>`

The as2rel accessor returns a new public `As2relExportEntry` struct with an `address_family` field, deduplicated to canonical (asn1 < asn2) order.

All new methods are marked `#[allow(dead_code)]` since they will be consumed by the export module in a subsequent PR (part of a stacked PR chain).

## Breaking change

None. Pure additions, no existing API modified.

## Verification

- `cargo clippy --all-features -- -D warnings` clean
- `cargo test --all-features --lib` 52 passed, 0 failed

**This is the bottom of a 4-PR stack.**