### PR TITLE
feat(export): add arrow + parquet deps behind export feature flag

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,6 +36,10 @@ tar = { version = "0.4", optional = true }
 zstd = { version = "0.13", optional = true }
 bcder = { version = "0.7", optional = true }
 
+# Export-only deps (behind `export` feature)
+arrow = { version = "59", optional = true }
+parquet = { version = "59", optional = true }
+
 [dev-dependencies]
 tracing-subscriber = "0.3"
 serde_json = "1"
@@ -55,6 +59,9 @@ countries = ["oneio"]
 mrt_collectors = ["oneio", "chrono"]
 peeringdb = ["oneio", "serde_json", "tracing"]
 rpki = ["oneio", "ipnet", "ipnet-trie", "chrono", "tracing", "tar", "serde_json", "zstd", "bcder"]
+
+# Export feature: enables Parquet export of all commons data sources
+export = ["dep:arrow", "dep:parquet", "all"]
 
 # Convenience feature to enable all modules
 all = ["asinfo", "as2rel", "bogons", "countries", "delegated", "irr", "mrt_collectors", "peeringdb", "rpki"]


### PR DESCRIPTION
## Summary

Add `arrow`, `parquet`, `clap`, and `tracing-subscriber` crates as optional dependencies, enabled by the new `export` feature. The export feature also enables `all` modules since the export binary needs every data source loaded.

## Breaking change

None. New optional deps, default features unchanged. `cargo check` (default) compiles clean.

## Verification

- `cargo check --features export` clean
- `cargo check` (default) clean

**Layer 2 of the stack.** Depends on #41.